### PR TITLE
Update to Java 8u201 in CentOS image

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -31,7 +31,7 @@ config:
       description: "CentOS"
       javaPackage:
         7: 1.7.0.201-2.6.16.1.el7_6
-        8: 1.8.0.191.b12-1.el7_6
+        8: 1.8.0.201.b09-2.el7_6
     jboss:
       deprecated: true
       from: "jboss/base-jdk"

--- a/images/centos/openjdk8/jdk/Dockerfile
+++ b/images/centos/openjdk8/jdk/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-1.8.0-openjdk-1.8.0.191.b12-1.el7_6 \ 
-       java-1.8.0-openjdk-devel-1.8.0.191.b12-1.el7_6 \ 
+       java-1.8.0-openjdk-1.8.0.201.b09-2.el7_6 \ 
+       java-1.8.0-openjdk-devel-1.8.0.201.b09-2.el7_6 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/java/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk8/jre/Dockerfile
+++ b/images/centos/openjdk8/jre/Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-1.8.0-openjdk-1.8.0.191.b12-1.el7_6 \ 
+       java-1.8.0-openjdk-1.8.0.201.b09-2.el7_6 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 


### PR DESCRIPTION
Update to the latest Java 8 update in CentOS...

https://centos.pkgs.org/7/centos-updates-x86_64/java-1.8.0-openjdk-1.8.0.201.b09-2.el7_6.x86_64.rpm.html