### PR TITLE
Upgrade to OpenJDK 11.0.4 on CentOS

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -5,7 +5,7 @@ fish-pepper:
     - version
     - type
   name: "fabric8/java"
-  build: "1.6.2"
+  build: "1.6.4"
 
 # Used for escaping in 'agent-bond-opts' where the same delimiters are used
 abSepOpen: "{{"
@@ -32,7 +32,7 @@ config:
       javaPackage:
         7: 1.7.0.221-2.6.18.0.el7_6
         8: 1.8.0.212.b04-0.el7_6
-        11: 11.0.3.7-0.el7_6
+        11: 11.0.4.11-1.el7_7
     jboss:
       deprecated: true
       from: "jboss/base-jdk"

--- a/images/centos/openjdk11/jdk/Dockerfile
+++ b/images/centos/openjdk11/jdk/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-11-openjdk-11.0.3.7-0.el7_6 \ 
-       java-11-openjdk-devel-11.0.3.7-0.el7_6 \ 
+       java-11-openjdk-11.0.4.11-1.el7_7 \ 
+       java-11-openjdk-devel-11.0.4.11-1.el7_7 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk11/jre/Dockerfile
+++ b/images/centos/openjdk11/jre/Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-11-openjdk-11.0.3.7-0.el7_6 \ 
+       java-11-openjdk-11.0.4.11-1.el7_7 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 


### PR DESCRIPTION
https://centos.pkgs.org/7/centos-updates-x86_64/java-11-openjdk-11.0.4.11-1.el7_7.x86_64.rpm.html

Closes: #49