### PR TITLE
Adding new UBI based images

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ fish-pepper
 The Java base images come in different flavors:
 
 * Based on [CentOS 7](https://www.centos.org/) or
-  [Alpine Linux](https://www.alpinelinux.org/) (experimental)
+  [Alpine Linux](https://www.alpinelinux.org/) (experimental) or [Red Hat Universal Base Image](https://developers.redhat.com/products/rhel/ubi/)
 * [OpenJDK 7](http://openjdk.java.net/projects/jdk7/) or
   [OpenJDK 8](http://openjdk.java.net/projects/jdk8/) or
   [OpenJDK 11](http://openjdk.java.net/projects/jdk/11/)

--- a/blocks/agent-bond-install.dck
+++ b/blocks/agent-bond-install.dck
@@ -1,0 +1,12 @@
+{{
+  var destPath = fp.blockOpts.dest || "/bin/agent-bond-options";
+  var agentBondVersion = fp.version.agentBond || fp.blockOpts.version || "1.2.0";
+}}# Agent bond including Jolokia and jmx_exporter
+ADD agent-bond-opts {{= destPath }}
+RUN mkdir -p /opt/agent-bond \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/{{= agentBondVersion }}/agent-bond-agent-{{= agentBondVersion }}.jar \
+          -o /opt/agent-bond/agent-bond.jar \
+ && chmod 444 /opt/agent-bond/agent-bond.jar \
+ && chmod 755 {{= destPath}}
+ADD jmx_exporter_config.yml /opt/agent-bond/
+EXPOSE 8778 9779

--- a/blocks/java-pkg-ubi.dck
+++ b/blocks/java-pkg-ubi.dck
@@ -1,0 +1,9 @@
+{{ var major = fp.config.version.major; }}
+# /dev/urandom is used as random source, which is prefectly safe
+# according to http://www.2uo.de/myths-about-urandom/
+RUN microdnf install java-{{= fp.config.version.version }}-openjdk-headless-{{= fp.config.base.javaPackage[major]}} \
+      openssl curl ca-certificates \
+    && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
+    && microdnf clean all
+
+ENV JAVA_HOME /etc/alternatives/jre

--- a/images.yml
+++ b/images.yml
@@ -34,6 +34,16 @@ config:
         7: 1.7.0.231-2.6.19.2.el7_7
         8: 1.8.0.232.b09-0.el7_7
         11: 11.0.5.10-0.el7_7
+    ubi:
+      from: "registry.access.redhat.com/ubi8/ubi-minimal:8.1-398"
+      createUser: false
+      createUBIUser: true
+      ubiUser: 1001 
+      version: "8.1"
+      description: "UBI"
+      javaPackage:
+        8: 1.8.0.242.b08-0.el8_1
+        11: 11.0.6.10-0.el8_1
     jboss:
       deprecated: true
       from: "jboss/base-jdk"
@@ -46,6 +56,10 @@ config:
       version: "1.7.0"
       description: "OpenJDK 7"
       major: 7
+      fish-pepper:
+        # Ignore for UBI as there are no Java 7 packages
+        ignore-for:
+           - [ "ubi" ]
     openjdk8:
       version: "1.8.0"
       description: "OpenJDK 8"
@@ -62,9 +76,10 @@ config:
   type:
     jre:
       description: "Java Runtime Environment (JRE)"
-      # Ignore JREs for JBoss image since there are no JRE variants for them available
+      # Ignore JREs for JBoss and UBI images since there are no JRE variants for them available
       fish-pepper:
         ignore-for:
            - [ "jboss" ]
+           - [ "ubi" ]
     jdk:
       description: "Java Development Kit (JDK)"

--- a/images/alpine/openjdk11/jre/Dockerfile
+++ b/images/alpine/openjdk11/jre/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --update \
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/alpine/openjdk7/jdk/Dockerfile
+++ b/images/alpine/openjdk7/jdk/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --update \
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/alpine/openjdk7/jre/Dockerfile
+++ b/images/alpine/openjdk7/jre/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --update \
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/alpine/openjdk8/jdk/Dockerfile
+++ b/images/alpine/openjdk8/jdk/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --update \
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/alpine/openjdk8/jre/Dockerfile
+++ b/images/alpine/openjdk8/jre/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --update \
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/centos/openjdk11/jdk/Dockerfile
+++ b/images/centos/openjdk11/jdk/Dockerfile
@@ -22,7 +22,7 @@ ENV JAVA_HOME /etc/alternatives/jre
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/centos/openjdk11/jre/Dockerfile
+++ b/images/centos/openjdk11/jre/Dockerfile
@@ -21,7 +21,7 @@ ENV JAVA_HOME /etc/alternatives/jre
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/centos/openjdk7/jdk/Dockerfile
+++ b/images/centos/openjdk7/jdk/Dockerfile
@@ -22,7 +22,7 @@ ENV JAVA_HOME /etc/alternatives/jre
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/centos/openjdk7/jre/Dockerfile
+++ b/images/centos/openjdk7/jre/Dockerfile
@@ -21,7 +21,7 @@ ENV JAVA_HOME /etc/alternatives/jre
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/centos/openjdk8/jdk/Dockerfile
+++ b/images/centos/openjdk8/jdk/Dockerfile
@@ -22,7 +22,7 @@ ENV JAVA_HOME /etc/alternatives/jre
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/centos/openjdk8/jre/Dockerfile
+++ b/images/centos/openjdk8/jre/Dockerfile
@@ -21,7 +21,7 @@ ENV JAVA_HOME /etc/alternatives/jre
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/jboss/openjdk7/jdk/Dockerfile
+++ b/images/jboss/openjdk7/jdk/Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_APP_DIR=/deployments \
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/jboss/openjdk8/jdk/Dockerfile
+++ b/images/jboss/openjdk8/jdk/Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_APP_DIR=/deployments \
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
 RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
+ && curl https://repo.maven.apache.org/maven2/io/fabric8/agent-bond-agent/1.2.0/agent-bond-agent-1.2.0.jar \
           -o /opt/agent-bond/agent-bond.jar \
  && chmod 444 /opt/agent-bond/agent-bond.jar \
  && chmod 755 /opt/run-java-options

--- a/images/ubi/openjdk11/jdk/Dockerfile
+++ b/images/ubi/openjdk11/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-398
 
 USER root
 
@@ -9,13 +9,14 @@ ENV JAVA_APP_DIR=/deployments \
     JAVA_MAJOR_VERSION=11
 
 
-# /dev/urandom is used as random source, which is perfectly safe
+# /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
-RUN apk add --update \
-    curl \
-    openjdk11=11.0.4_p4-r1 \
- && rm /var/cache/apk/* \
- && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/default-jvm/jre/lib/security/java.security
+RUN microdnf install java-11-openjdk-headless-11.0.6.10-0.el8_1 \
+      openssl curl ca-certificates \
+    && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
+    && microdnf clean all
+
+ENV JAVA_HOME /etc/alternatives/jre
 
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
@@ -33,5 +34,17 @@ RUN chmod 755 /deployments/run-java.sh
 
 
 
+
+# Run under user "1001" and prepare for be running
+# under OpenShift, too
+RUN chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && chmod g+rw /etc/passwd \
+    && mkdir -p /deployments/data \
+    && chown 1001 /deployments/run-java.sh
+
+# Gives uid
+USER 1001
 
 CMD [ "/deployments/run-java.sh" ]

--- a/images/ubi/openjdk11/jdk/README.md
+++ b/images/ubi/openjdk11/jdk/README.md
@@ -1,0 +1,184 @@
+## Fabric8 Java Base Image OpenJDK 11 (JDK)
+
+
+
+This image is based on UBI and provides OpenJDK 11 (JDK)
+
+It includes:
+
+
+* An [Agent Bond](https://github.com/fabric8io/agent-bond) agent with [Jolokia](http://www.jolokia.org) and Prometheus' [jmx_exporter](https://github.com/prometheus/jmx_exporter). The agent is installed as `/opt/agent-bond/agent-bond.jar`. See below for configuration options.
+
+
+* A startup script [`/deployments/run-java.sh`](#startup-script-run-javash) for starting up Java applications.
+
+### Agent Bond
+
+In order to enable Jolokia for your application you should use this image as a base image (via `FROM`) and use the output of `agent-bond-opts` in your startup scripts to include it in for the Java startup options.
+
+For example, the following snippet can be added to a script starting up your Java application
+
+    # ...
+    export JAVA_OPTIONS="$JAVA_OPTIONS $(agent-bond-opts)"
+    # .... use JAVA_OPTIONS when starting your app, e.g. as Tomcat does
+
+The following versions and defaults are used:
+
+* [Jolokia](http://www.jolokia.org) : version **1.6.2** and port **8778**
+* [jmx_exporter](https://github.com/prometheus/jmx_exporter): version **0.3.1** and port **9779**
+
+You can influence the behaviour of `agent-bond-opts` by setting various environment variables:
+
+### Agent-Bond Options
+
+Agent bond itself can be influenced with the following environment variables: 
+
+* **AB_OFF** : If set disables activation of agent-bond (i.e. echos an empty value). By default, agent-bond is enabled.
+* **AB_ENABLED** : Comma separated list of sub-agents enabled. Currently allowed values are `jolokia` and `jmx_exporter`. 
+  By default both are enabled.
+
+
+#### Jolokia configuration
+
+* **AB_JOLOKIA_CONFIG** : If set uses this file (including path) as Jolokia JVM agent properties (as described 
+  in Jolokia's [reference manual](http://www.jolokia.org/reference/html/agents.html#agents-jvm)).
+  By default this is `/opt/jolokia/jolokia.properties`.
+* **AB_JOLOKIA_HOST** : Host address to bind to (Default: `0.0.0.0`)
+* **AB_JOLOKIA_PORT** : Port to use (Default: `8778`)
+* **AB_JOLOKIA_USER** : User for authentication. By default authentication is switched off.
+* **AB_JOLOKIA_HTTPS** : Switch on secure communication with https. By default self signed server certificates are generated
+  if no `serverCert` configuration is given in `AB_JOLOKIA_OPTS`
+* **AB_JOLOKIA_PASSWORD** : Password for authentication. By default authentication is switched off.
+* **AB_JOLOKIA_ID** : Agent ID to use (`$HOSTNAME` by default, which is the container id)
+* **AB_JOLOKIA_OPTS**  : Additional options to be appended to the agent opts. They should be given in the format 
+  "key=value,key=value,..."
+
+Some options for integration in various environments:
+
+* **AB_JOLOKIA_AUTH_OPENSHIFT** : Switch on client authentication for OpenShift TLS communication. The value of this 
+  parameter can be a relative distinguished name which must be contained in a presented client certificate. Enabling this
+  parameter will automatically switch Jolokia into https communication mode. The default CA cert is set to 
+  `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` 
+  
+#### jmx_exporter configuration
+
+* **AB_JMX_EXPORTER_OPTS** : Configuration to use for `jmx_exporter` (in the format `<port>:<path to config>`)
+* **AB_JMX_EXPORTER_PORT** : Port to use for the JMX Exporter. Default: `9779`
+* **AB_JMX_EXPORTER_CONFIG** : Path to configuration to use for `jmx_exporter`: Default: `/opt/agent-bond/jmx_exporter_config.json`
+
+
+
+### Startup Script run-java.sh
+
+The default command for this image is [/deployments/run-java.sh](https://github.com/fabric8io/run-java-sh). Its purpose it to fire up Java applications which are provided as fat-jars, including all dependencies or more classical from a main class, where the classpath is build up from all jars within a directory.
+
+For these images the variable **JAVA_APP_DIR** has the default value `/deployments`
+
+
+### run-java.sh
+
+This general purpose startup script is optimized for running Java application from within containers. It is called like
+
+```
+./run-java.sh <sub-command> <options>
+```
+`run-java.sh` knows two sub-commands:
+
+* `options` to print out JVM option which can be used for own invocation of Java apps (like Maven or Tomcat). It respects container constraints and includes all magic which is used by this script
+* `run` executes a Java application as described below. This is also the default command so you can skip adding this command.
+
+### Running a Java application
+
+When no subcommand is given (or when you provide the default subcommand `run`), then by default this scripts starts up Java application.
+
+The startup process is configured mostly via environment variables:
+
+* **JAVA_APP_DIR** the directory where the application resides. All paths in your application are relative to this directory. By default it is the same directory where this startup script resides.
+* **JAVA_LIB_DIR** directory holding the Java jar files as well an optional `classpath` file which holds the classpath. Either as a single line classpath (colon separated) or with jar files listed line-by-line. If not set **JAVA_LIB_DIR** is the same as **JAVA_APP_DIR**.
+* **JAVA_OPTIONS** options to add when calling `java`
+* **JAVA_MAJOR_VERSION** a number >= 7. If the version is set then only options suitable for this version are used. When set to 7 options known only to Java > 8 will be removed. For versions >= 10 no explicit memory limit is calculated since Java >= 10 has support for container limits.
+* **JAVA_MAX_MEM_RATIO** is used when no `-Xmx` option is given in `JAVA_OPTIONS`. This is used to calculate a default maximal Heap Memory based on a containers restriction. If used in a Docker container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `25` when the maximum amount of memory available to the container is below 300M, `50` otherwise, which means in that case that 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to 0 in which case no `-Xmx` option is added.
+* **JAVA_INIT_MEM_RATIO** is used when no `-Xms` option is given in `JAVA_OPTIONS`. This is used to calculate a default initial Heap Memory based on a containers restriction. If used in a Docker container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xms` is set to a ratio of the container available memory as set here. By default this value is not set.
+* **JAVA_MAX_CORE** restrict manually the number of cores available which is used for calculating certain defaults like the number of garbage collector threads. If set to 0 no base JVM tuning based on the number of cores is performed.
+* **JAVA_DIAGNOSTICS** set this to get some diagnostics information to standard out when things are happening
+* **JAVA_MAIN_CLASS** A main class to use as argument for `java`. When this environment variable is given, all jar files in `$JAVA_APP_DIR` are added to the classpath as well as `$JAVA_LIB_DIR`.
+* **JAVA_APP_JAR** A jar file with an appropriate manifest so that it can be started with `java -jar` if no `$JAVA_MAIN_CLASS` is set. In all cases this jar file is added to the classpath, too.
+* **JAVA_APP_NAME** Name to use for the process
+* **JAVA_CLASSPATH** the classpath to use. If not given, the startup script checks for a file `${JAVA_APP_DIR}/classpath` and use its content literally as classpath. If this file doesn't exists all jars in the app dir are added (`classes:${JAVA_APP_DIR}/*`).
+* **JAVA_DEBUG** If set remote debugging will be switched on
+* **JAVA_DEBUG_SUSPEND** If set enables suspend mode in remote debugging
+* **JAVA_DEBUG_PORT** Port used for remote debugging. Default: 5005
+* **HTTP_PROXY** The URL of the proxy server that translates into the `http.proxyHost` and `http.proxyPort` system properties.
+* **HTTPS_PROXY** The URL of the proxy server that translates into the `https.proxyHost` and `https.proxyPort` system properties.
+* **no_proxy**, **NO_PROXY** The list of hosts that should be reached directly, bypassing the proxy, that translates into the `http.nonProxyHosts` system property.
+
+If neither `$JAVA_APP_JAR` nor `$JAVA_MAIN_CLASS` is given, `$JAVA_APP_DIR` is checked for a single JAR file which is taken as `$JAVA_APP_JAR`. If no or more then one jar file is found, an error is thrown.
+
+The classpath is build up with the following parts:
+
+* If `$JAVA_CLASSPATH` is set, this classpath is taken.
+* The current directory (".") is added first.
+* If the current directory is not the same as `$JAVA_APP_DIR`, `$JAVA_APP_DIR` is added.
+* If `$JAVA_MAIN_CLASS` is set, then
+  - A `$JAVA_APP_JAR` is added if set
+  - If a file `$JAVA_APP_DIR/classpath` exists, its content is appended to the classpath. This file
+    can be either a single line with the jar files colon separated or a multi-line file where each line
+    holds the path of the jar file relative to `$JAVA_LIB_DIR` (which by default is the `$JAVA_APP_DIR`)
+  - If this file is not set, a `${JAVA_APP_DIR}/*` is added which effectively adds all
+    jars in this directory in alphabetical order.
+
+These variables can be also set in a shell config file `run-env.sh`, which will be sourced by the startup script. This file can be located in the directory where the startup script is located and in `${JAVA_APP_DIR}`, whereas environment variables in the latter override the ones in `run-env.sh` from the script directory.
+
+This startup script also checks for a command `run-java-options`. If existent it will be called and the output is added to the environment variable `$JAVA_OPTIONS`.
+
+The startup script also exposes some environment variables describing container limits which can be used by applications:
+
+* **CONTAINER_CORE_LIMIT** a calculated core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
+* **CONTAINER_MAX_MEMORY** memory limit given to the container
+
+Any arguments given to the script are given through directly as argument to the Java application.
+
+Example:
+
+```
+# Set the application directory directly
+export JAVA_APP_DIR=/deployments
+# Set -Xmx based on container constraints
+export JAVA_MAX_MEM_RATIO=40
+# Start the jar in JAVA_APP_DIR with the given arguments
+./run-java.sh --user maxmorlock --password secret
+```
+
+### Options
+
+This script can also be used to calculate reasonable, best-practice options for starting Java apps in general. For example, when running Maven in a container it makes sense to respect  container Memory constraints.
+
+The subcommand `options` can be used to print options to standard output so that is can be easily used to feed it to another, Java based application.
+
+When no extra arguments are given, all defaults will be used, which can be influenced with the environment variables described above.
+
+You can select specific sets of options by providing additional arguments:
+
+* `--debug` : Java debug options if `JAVA_DEBUG` is set
+* `--memory` : Memory settings based on the environment variables given
+* `--proxy` : Evaluate proxy environments variables
+* `--cpu` : Tuning when the number of cores is limited
+* `--gc` : GC tuning parameters
+* `--jit` : JIT options
+* `--diagnostics` : Print diagnostics options when `JAVA_DIAGNOSTICS` is set
+* `--java-default` : Same as `--memory --jit --diagnostic --cpu --gc`
+
+Example:
+
+```
+# Call Maven with the proper memory settings when running in an container
+export MAVEN_OPTS="$(run-java.sh options --memory)"
+mvn clean install
+```
+
+
+### Versions:
+
+* Base-Image: **UBI 8.1**
+* Java: **OpenJDK 11 11** (Java Development Kit (JDK))
+* Agent-Bond: **1.2.0** (Jolokia 1.6.2, jmx_exporter 0.3.1)

--- a/images/ubi/openjdk11/jdk/agent-bond-opts
+++ b/images/ubi/openjdk11/jdk/agent-bond-opts
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+# Parse options
+while [ $# -gt 0 ]
+do
+key="$1"
+case ${key} in
+    # Escape for scripts which eval the output of this script
+    -e|--escape)
+    escape_sep=1
+    ;;
+esac
+shift
+done
+
+# Check whether a given config is contained in AB_JOLOKIA_OPTS
+is_in_jolokia_opts() {
+  local prop=$1
+  if [ -n "${AB_JOLOKIA_OPTS:-}" ] && [ "${AB_JOLOKIA_OPTS}" != "${AB_JOLOKIA_OPTS/${prop}/}" ]; then
+     echo "yes"
+  else
+     echo "no"
+  fi
+}
+
+dir=${AB_DIR:-/opt/agent-bond}
+sep="="
+
+# Options separators defined to avoid clash with fish-pepper templating
+ab_open_del="{""{"
+ab_close_del="}""}"
+if [ -n "${escape_sep:-}" ]; then
+  ab_open_del='\{\{'
+  ab_close_del='\}\}'
+fi
+
+if [ -z "${AB_OFF:-}" ]; then
+   opts="-javaagent:$dir/agent-bond.jar"
+   config="${AB_CONFIG:-$dir/agent-bond.properties}"
+   if [ -f "$config" ]; then
+      # Configuration takes precedence
+      opts="${opts}${sep}config=${config}"
+      sep=","
+   fi
+   if [ -z "${AB_ENABLED:-}" ] || [ "${AB_ENABLED}" != "${AB_ENABLED/jolokia/}" ]; then
+     # Direct options only if no configuration is found
+     jsep=""
+     jolokia_opts=""
+     if [ -n "${AB_JOLOKIA_CONFIG:-}" ] && [ -f "${AB_JOLOKIA_CONFIG}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}config=${AB_JOLOKIA_CONFIG}"
+        jsep=","
+        grep -q -e '^host' ${AB_JOLOKIA_CONFIG} && host_in_config=1
+     fi
+     if [ -z "${AB_JOLOKIA_HOST:-}" ] && [ -z "${host_in_config:-}" ]; then
+        AB_JOLOKIA_HOST='0.0.0.0'
+     fi
+     if [ -n "${AB_JOLOKIA_HOST:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}host=${AB_JOLOKIA_HOST}"
+        jsep=","
+     fi
+     if [ -n "${AB_JOLOKIA_PORT:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}port=${AB_JOLOKIA_PORT}"
+        jsep=","
+     fi
+     if [ -n "${AB_JOLOKIA_USER:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}user=${AB_JOLOKIA_USER}"
+        jsep=","
+     fi
+     if [ -n "${AB_JOLOKIA_PASSWORD:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}password=${AB_JOLOKIA_PASSWORD}"
+        jsep=","
+     fi
+     if [ -n "${AB_JOLOKIA_HTTPS:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}protocol=https"
+        https_used=1
+        jsep=","
+     fi
+     # Integration with OpenShift client cert auth
+     if [ -n "${AB_JOLOKIA_AUTH_OPENSHIFT:-}" ]; then
+        auth_opts="useSslClientAuthentication=true,extraClientCheck=true"
+        if [ -z "${https_used+x}" ]; then
+          auth_opts="${auth_opts},protocol=https"
+        fi
+        if [ $(is_in_jolokia_opts "caCert") != "yes" ]; then
+           auth_opts="${auth_opts},caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        fi
+        if [ $(is_in_jolokia_opts "clientPrincipal") != "yes" ]; then
+           if [  "${AB_JOLOKIA_AUTH_OPENSHIFT}" != "${AB_JOLOKIA_AUTH_OPENSHIFT/=/}" ]; then
+              # Supposed to contain a principal name to check
+              auth_opts="${auth_opts},clientPrincipal=$(echo ${AB_JOLOKIA_AUTH_OPENSHIFT} | sed -e 's/ /\\\\ /g')"
+           else
+              auth_opts="${auth_opts},clientPrincipal=cn=system:master-proxy"
+           fi
+        fi
+        jolokia_opts="${jolokia_opts}${jsep}${auth_opts}"
+        jsep=","
+     fi
+     # Add extra opts to the end
+     if [ -n "${AB_JOLOKIA_OPTS:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}${AB_JOLOKIA_OPTS}"
+        jsep=","
+     fi
+
+     opts="${opts}${sep}jolokia${ab_open_del}${jolokia_opts}${ab_close_del}"
+     sep=","
+   fi
+   if [ -z "${AB_ENABLED:-}" ] || [ "${AB_ENABLED}" != "${AB_ENABLED/jmx_exporter/}" ]; then
+     je_opts=""
+     jsep=""
+     if [ -n "${AB_JMX_EXPORTER_OPTS:-}" ]; then
+        opts="${opts}${sep}jmx_exporter${ab_open_del}${AB_JMX_EXPORTER_OPTS}${ab_close_del}"
+        sep=","
+     else
+        port=${AB_JMX_EXPORTER_PORT:-9779}
+        config=${AB_JMX_EXPORTER_CONFIG:-/opt/agent-bond/jmx_exporter_config.yml}
+        opts="${opts}${sep}jmx_exporter${ab_open_del}${port}:${config}${ab_close_del}"
+        sep=","
+     fi
+   fi
+   if [ "${sep:-}" != '=' ] ; then
+     echo ${opts}
+   fi
+fi

--- a/images/ubi/openjdk11/jdk/jmx_exporter_config.yml
+++ b/images/ubi/openjdk11/jdk/jmx_exporter_config.yml
@@ -1,0 +1,28 @@
+---
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+whitelistObjectNames:
+  - 'org.apache.camel:*'
+rules:
+  - pattern: '^org.apache.camel<context=(\w+), type=routes, name=\"(\S+)\"><>((?:Min|Mean|Max|Last|Delta)(?:ProcessingTime)):'
+    name: camel_routes_$3
+    labels:
+      name: $2
+      context: $1
+  - pattern: '^org.apache.camel<context=(\w+), type=routes, name=\"(\S+)\"><>(TotalProcessingTime):'
+    type: COUNTER
+    name: camel_routes_$3
+    labels:
+      name: $2
+      context: $1
+  - pattern: '^org.apache.camel<context=(\w+), type=routes, name=\"(\S+)\"><>(ExchangesInflight|LastProcessingTime):'
+    name: camel_routes_$3
+    labels:
+      name: $2
+      context: $1
+  - pattern: '^org.apache.camel<context=(\w+), type=routes, name=\"(\S+)\"><>((?:Exchanges(?:Completed|Failed|Total))|FailuresHandled):'
+    type: COUNTER
+    name: camel_routes_$3
+    labels:
+      name: $2
+      context: $1

--- a/images/ubi/openjdk11/jdk/run-java.sh
+++ b/images/ubi/openjdk11/jdk/run-java.sh
@@ -1,0 +1,625 @@
+#!/bin/sh
+# ===================================================================================
+# Generic startup script for running arbitrary Java applications with
+# being optimized for running in containers
+#
+# Usage:
+#    # Execute a Java app:
+#    ./run-java.sh <args given to Java code>
+#
+#    # Get options which can be used for invoking Java apps like Maven or Tomcat
+#    ./run-java.sh options [....]
+#
+#
+# This script will pick up either a 'fat' jar which can be run with "-jar"
+# or you can sepcify a JAVA_MAIN_CLASS.
+#
+# Source and Documentation can be found
+# at https://github.com/fabric8io-images/run-java-sh
+#
+# Env-variables evaluated in this script:
+#
+# JAVA_OPTIONS: Checked for already set options
+# JAVA_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
+#                     E.g. the "50" value implies that 50% of the Memory
+#                     given to the container is used as the maximum heap memory with
+#                     '-Xmx'.
+#                     It defaults to "25" when the maximum amount of memory available
+#                     to the container is below 300M, otherwise defaults to "50".
+#                     It is a heuristic and should be better backed up with real
+#                     experiments and measurements.
+#                     For a good overviews what tuning options are available -->
+#                             https://youtu.be/Vt4G-pHXfs4
+#                             https://www.youtube.com/watch?v=w1rZOY5gbvk
+#                             https://vimeo.com/album/4133413/video/181900266
+# Also note that heap is only a small portion of the memory used by a JVM. There are lot
+# of other memory areas (metadata, thread, code cache, ...) which addes to the overall
+# size. When your container gets killed because of an OOM, then you should tune
+# the absolute values.
+# JAVA_INIT_MEM_RATIO: Ratio use to calculate a default intial heap memory, in percent.
+#                      By default this value is not set.
+#
+# The following variables are exposed to your Java application:
+#
+# CONTAINER_MAX_MEMORY: Max memory for the container (if running within a container)
+# MAX_CORE_LIMIT: Number of cores available for the container (if running within a container)
+
+
+# ==========================================================
+
+# Fail on a single failed command in a pipeline (if supported)
+(set -o | grep -q pipefail) && set -o pipefail
+
+# Fail on error and undefined vars
+set -eu
+
+# Save global script args
+ARGS="$@"
+
+# ksh is different for defining local vars
+if [ -n "${KSH_VERSION:-}" ]; then
+  alias local=typeset
+fi
+
+# Error is indicated with a prefix in the return value
+check_error() {
+  local error_msg="$1"
+  if echo "${error_msg}" | grep -q "^ERROR:"; then
+    echo "${error_msg}"
+    exit 1
+  fi
+}
+
+# The full qualified directory where this script is located in
+script_dir() {
+  # Default is current directory
+  local dir=$(dirname "$0")
+  local full_dir=$(cd "${dir}" && pwd)
+  echo ${full_dir}
+}
+
+# Try hard to find a sane default jar-file
+auto_detect_jar_file() {
+  local dir="$1"
+
+  # Filter out temporary jars from the shade plugin which start with 'original-'
+  local old_dir="$(pwd)"
+  cd ${dir}
+  if [ $? = 0 ]; then
+    # NB: Find both (single) JAR *or* WAR <https://github.com/fabric8io-images/run-java-sh/issues/79>
+    local nr_jars="$(ls 2>/dev/null | grep -e '.*\.jar$' -e '.*\.war$' | grep -v '^original-' | wc -l | awk '{print $1}')"
+    if [ "${nr_jars}" = 1 ]; then
+      ls 2>/dev/null | grep -e '.*\.jar$' -e '.*\.war$' | grep -v '^original-'
+      exit 0
+    fi
+    cd "${old_dir}"
+    echo "ERROR: Neither JAVA_MAIN_CLASS nor JAVA_APP_JAR is set and ${nr_jars} found in ${dir} (1 expected)"
+  else
+    echo "ERROR: No directory ${dir} found for auto detection"
+  fi
+}
+
+# Check directories (arg 2...n) for a jar file (arg 1)
+find_jar_file() {
+  local jar="$1"
+  shift;
+
+  # Absolute path check if jar specifies an absolute path
+  if [ "${jar}" != ${jar#/} ]; then
+    if [ -f "${jar}" ]; then
+      echo "${jar}"
+    else
+      echo "ERROR: No such file ${jar}"
+    fi
+  else
+    for dir in $*; do
+      if [ -f "${dir}/$jar" ]; then
+        echo "${dir}/$jar"
+        return
+      fi
+    done
+    echo "ERROR: No ${jar} found in $*"
+  fi
+}
+
+# Generic formula evaluation based on awk
+calc() {
+  local formula="$1"
+  shift
+  echo "$@" | awk '
+    function ceil(x) {
+      return x % 1 ? int(x) + 1 : x
+    }
+    function log2(x) {
+      return log(x)/log(2)
+    }
+    function max2(x, y) {
+      return x > y ? x : y
+    }
+    function round(x) {
+      return int(x + 0.5)
+    }
+    {print '"int(${formula})"'}
+  '
+}
+
+# Based on the cgroup limits, figure out the max number of core we should utilize
+core_limit() {
+  local cpu_period_file="/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+  local cpu_quota_file="/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+  if [ -r "${cpu_period_file}" ]; then
+    local cpu_period="$(cat ${cpu_period_file})"
+
+    if [ -r "${cpu_quota_file}" ]; then
+      local cpu_quota="$(cat ${cpu_quota_file})"
+      # cfs_quota_us == -1 --> no restrictions
+      if [ ${cpu_quota:-0} -ne -1 ]; then
+        echo $(calc 'ceil($1/$2)' "${cpu_quota}" "${cpu_period}")
+      fi
+    fi
+  fi
+}
+
+max_memory() {
+  # High number which is the max limit until which memory is supposed to be
+  # unbounded.
+  local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+  if [ -r "${mem_file}" ]; then
+    local max_mem_cgroup="$(cat ${mem_file})"
+    local max_mem_meminfo_kb="$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')"
+    local max_mem_meminfo="$(expr $max_mem_meminfo_kb \* 1024)"
+    if [ ${max_mem_cgroup:-0} != -1 ] && [ ${max_mem_cgroup:-0} -lt ${max_mem_meminfo:-0} ]
+    then
+      echo "${max_mem_cgroup}"
+    fi
+  fi
+}
+
+init_limit_env_vars() {
+  # Read in container limits and export the as environment variables
+  local core_limit="$(core_limit)"
+  if [ -n "${core_limit}" ]; then
+    export CONTAINER_CORE_LIMIT="${core_limit}"
+  fi
+
+  local mem_limit="$(max_memory)"
+  if [ -n "${mem_limit}" ]; then
+    export CONTAINER_MAX_MEMORY="${mem_limit}"
+  fi
+}
+
+load_env() {
+  local script_dir="$1"
+
+  # Configuration stuff is read from this file
+  local run_env_sh="run-env.sh"
+
+  # Load default default config
+  if [ -f "${script_dir}/${run_env_sh}" ]; then
+    . "${script_dir}/${run_env_sh}"
+  fi
+
+  # Check also $JAVA_APP_DIR. Overrides other defaults
+  # It's valid to set the app dir in the default script
+  JAVA_APP_DIR="${JAVA_APP_DIR:-${script_dir}}"
+  if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
+    . "${JAVA_APP_DIR}/${run_env_sh}"
+  fi
+  export JAVA_APP_DIR
+
+  # JAVA_LIB_DIR defaults to JAVA_APP_DIR
+  export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"
+  if [ -z "${JAVA_MAIN_CLASS:-}" ] && [ -z "${JAVA_APP_JAR:-}" ]; then
+    JAVA_APP_JAR="$(auto_detect_jar_file ${JAVA_APP_DIR})"
+    check_error "${JAVA_APP_JAR}"
+  fi
+
+  if [ -n "${JAVA_APP_JAR:-}" ]; then
+    local jar="$(find_jar_file ${JAVA_APP_JAR} ${JAVA_APP_DIR} ${JAVA_LIB_DIR})"
+    check_error "${jar}"
+    export JAVA_APP_JAR="${jar}"
+  else
+    export JAVA_MAIN_CLASS
+  fi
+}
+
+# Check for standard /opt/run-java-options first, fallback to run-java-options in the path if not existing
+run_java_options() {
+  if [ -f "/opt/run-java-options" ]; then
+    echo "$(. /opt/run-java-options)"
+  else
+    which run-java-options >/dev/null 2>&1
+    if [ $? = 0 ]; then
+      echo "$(run-java-options)"
+    fi
+  fi
+}
+
+debug_options() {
+  if [ -n "${JAVA_ENABLE_DEBUG:-}" ] || [ -n "${JAVA_DEBUG_ENABLE:-}" ] ||  [ -n "${JAVA_DEBUG:-}" ]; then
+    local debug_port="${JAVA_DEBUG_PORT:-5005}"
+    local suspend_mode="n"
+    if [ -n "${JAVA_DEBUG_SUSPEND:-}" ]; then
+      if ! echo "${JAVA_DEBUG_SUSPEND}" | grep -q -e '^\(false\|n\|no\|0\)$'; then
+        suspend_mode="y"
+      fi
+    fi
+    echo "-agentlib:jdwp=transport=dt_socket,server=y,suspend=${suspend_mode},address=${debug_port}"
+  fi
+}
+
+# Read in a classpath either from a file with a single line, colon separated
+# or given line-by-line in separate lines
+# Arg 1: path to claspath (must exist), optional arg2: application jar, which is stripped from the classpath in
+# multi line arrangements
+format_classpath() {
+  local cp_file="$1"
+  local app_jar="${2:-}"
+
+  local wc_out="$(wc -l $1 2>&1)"
+  if [ $? -ne 0 ]; then
+    echo "Cannot read lines in ${cp_file}: $wc_out"
+    exit 1
+  fi
+
+  local nr_lines=$(echo $wc_out | awk '{ print $1 }')
+  if [ ${nr_lines} -gt 1 ]; then
+    local sep=""
+    local classpath=""
+    while read file; do
+      local full_path="${JAVA_LIB_DIR}/${file}"
+      # Don't include app jar if include in list
+      if [ "${app_jar}" != "${full_path}" ]; then
+        classpath="${classpath}${sep}${full_path}"
+      fi
+      sep=":"
+    done < "${cp_file}"
+    echo "${classpath}"
+  else
+    # Supposed to be a single line, colon separated classpath file
+    cat "${cp_file}"
+  fi
+}
+
+# ==========================================================================
+
+memory_options() {
+  echo "$(calc_init_memory) $(calc_max_memory)"
+  return
+}
+
+# Check for memory options and set max heap size if needed
+calc_max_memory() {
+  # Check whether -Xmx is already given in JAVA_OPTIONS
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xmx"; then
+    return
+  fi
+
+  if [ -z "${CONTAINER_MAX_MEMORY:-}" ]; then
+    return
+  fi
+
+  # Check for the 'real memory size' and calculate Xmx from the ratio
+  if [ -n "${JAVA_MAX_MEM_RATIO:-}" ]; then
+    if [ "${JAVA_MAX_MEM_RATIO}" -eq 0 ]; then
+      # Explicitely switched off
+      return
+    fi
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"
+  # When JAVA_MAX_MEM_RATIO not set and JVM >= 10 no max_memory
+  elif [ "${JAVA_MAJOR_VERSION:-0}" -ge "10" ]; then
+    return
+  elif [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
+    # Restore the one-fourth default heap size instead of the one-half below 300MB threshold
+    # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html#default_heap_size
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "25" "mx"
+  else
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "50" "mx"
+  fi
+}
+
+# Check for memory options and set initial heap size if requested
+calc_init_memory() {
+  # Check whether -Xms is already given in JAVA_OPTIONS.
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xms"; then
+    return
+  fi
+
+  # Check if value set
+  if [ -z "${JAVA_INIT_MEM_RATIO:-}" ] || [ -z "${CONTAINER_MAX_MEMORY:-}" ] || [ "${JAVA_INIT_MEM_RATIO}" -eq 0 ]; then
+    return
+  fi
+
+  # Calculate Xms from the ratio given
+  calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_INIT_MEM_RATIO}" "ms"
+}
+
+calc_mem_opt() {
+  local max_mem="$1"
+  local fraction="$2"
+  local mem_opt="$3"
+
+  local val=$(calc 'round($1*$2/100/1048576)' "${max_mem}" "${fraction}")
+  echo "-X${mem_opt}${val}m"
+}
+
+c2_disabled() {
+  if [ -n "${CONTAINER_MAX_MEMORY:-}" ]; then
+    # Disable C2 compiler when container memory <=300MB
+    if [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
+      echo true
+      return
+    fi
+  fi
+  echo false
+}
+
+jit_options() {
+  if [ "${JAVA_MAJOR_VERSION:-0}" -ge "10" ]; then
+    return
+  fi
+  # Check whether -XX:TieredStopAtLevel is already given in JAVA_OPTIONS
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-XX:TieredStopAtLevel"; then
+    return
+  fi
+  if [ $(c2_disabled) = true ]; then
+    echo "-XX:TieredStopAtLevel=1"
+  fi
+}
+
+# Switch on diagnostics except when switched off
+diagnostics_options() {
+  if [ -n "${JAVA_DIAGNOSTICS:-}" ]; then
+    if [ "${JAVA_MAJOR_VERSION:-0}" -ge "11" ]; then
+      echo "-XX:NativeMemoryTracking=summary -Xlog:gc*:stdout:time -XX:+UnlockDiagnosticVMOptions"
+    else
+      echo "-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
+    fi
+  fi
+}
+
+# Replicate thread ergonomics for tiered compilation.
+# This could ideally be skipped when tiered compilation is disabled.
+# The algorithm is taken from:
+# OpenJDK / jdk8u / jdk8u / hotspot
+# src/share/vm/runtime/advancedThresholdPolicy.cpp
+ci_compiler_count() {
+  local core_limit="$1"
+  local log_cpu=$(calc 'log2($1)' "$core_limit")
+  local loglog_cpu=$(calc 'log2(max2($1,1))' "$log_cpu")
+  local count=$(calc 'max2($1*$2,1)*3/2' "$log_cpu" "$loglog_cpu")
+  local c1_count=$(calc 'max2($1/3,1)' "$count")
+  local c2_count=$(calc 'max2($1-$2,1)' "$count" "$c1_count")
+  [ $(c2_disabled) = true ] && echo "$c1_count" || echo $(calc '$1+$2' "$c1_count" "$c2_count")
+}
+
+cpu_options() {
+  # JVMs >= 10 know about CPU limits
+  if [ "${JAVA_MAJOR_VERSION:-0}" -ge "10" ]; then
+    return
+  fi
+
+  local core_limit="${JAVA_CORE_LIMIT:-}"
+  if [ "$core_limit" = "0" ]; then
+    return
+  fi
+
+  if [ -n "${CONTAINER_CORE_LIMIT:-}" ]; then
+    if [ -z ${core_limit} ]; then
+      core_limit="${CONTAINER_CORE_LIMIT}"
+    fi
+    echo "-XX:ParallelGCThreads=${core_limit} " \
+         "-XX:ConcGCThreads=${core_limit} " \
+         "-Djava.util.concurrent.ForkJoinPool.common.parallelism=${core_limit} " \
+         "-XX:CICompilerCount=$(ci_compiler_count $core_limit)"
+  fi
+}
+
+#-XX:MinHeapFreeRatio=20  These parameters tell the heap to shrink aggressively and to grow conservatively.
+#-XX:MaxHeapFreeRatio=40  Thereby optimizing the amount of memory available to the operating system.
+heap_ratio() {
+  echo "-XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40"
+}
+
+# These parameters are necessary when running parallel GC if you want to use the Min and Max Heap Free ratios.
+# Skip setting gc_options if any other GC is set in JAVA_OPTIONS.
+# -XX:GCTimeRatio=4
+# -XX:AdaptiveSizePolicyWeight=90
+gc_options() {
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-XX:.*Use.*GC"; then
+    return
+  fi
+
+  local opts=""
+  # for JVMs < 10 set GC settings
+  if [ -z "${JAVA_MAJOR_VERSION:-}" ] || [ "${JAVA_MAJOR_VERSION:-0}" -lt "10" ]; then
+    opts="${opts} -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 $(heap_ratio)"
+  fi
+  if [ -z "${JAVA_MAJOR_VERSION:-}" ] || [ "${JAVA_MAJOR_VERSION:-}" != "7" ]; then
+    opts="${opts} -XX:+ExitOnOutOfMemoryError"
+  fi
+  echo $opts
+}
+
+java_default_options() {
+  # Echo options, trimming trailing and multiple spaces
+  echo "$(memory_options) $(jit_options) $(diagnostics_options) $(cpu_options) $(gc_options)" | awk '$1=$1'
+
+}
+
+# ==============================================================================
+
+# parse the URL
+parse_url() {
+  #[scheme://][user[:password]@]host[:port][/path][?params]
+  echo "$1" | sed -e "s+^\(\([^:]*\)://\)\?\(\([^:@]*\)\(:\([^@]*\)\)\?@\)\?\([^:/?]*\)\(:\([^/?]*\)\)\?.*$+ local scheme='\2' username='\4' password='\6' hostname='\7' port='\9'+"
+}
+
+java_proxy_options() {
+  local url="$1"
+  local transport="$2"
+  local ret=""
+
+  if [ -n "$url" ] ; then
+    eval $(parse_url "$url")
+    if [ -n "$hostname" ] ; then
+      ret="-D${transport}.proxyHost=${hostname}"
+    fi
+    if [ -n "$port" ] ; then
+      ret="$ret -D${transport}.proxyPort=${port}"
+    fi
+    if [ -n "$username" -o -n "$password" ] ; then
+      echo "WARNING: Proxy URL for ${transport} contains authentication credentials, these are not supported by java" >&2
+    fi
+  fi
+  echo "$ret"
+}
+
+# Check for proxy options and echo if enabled.
+proxy_options() {
+  local ret=""
+  ret="$(java_proxy_options "${https_proxy:-${HTTPS_PROXY:-}}" https)"
+  ret="$ret $(java_proxy_options "${http_proxy:-${HTTP_PROXY:-}}" http)"
+
+  local noProxy="${no_proxy:-${NO_PROXY:-}}"
+  if [ -n "$noProxy" ] ; then
+    ret="$ret -Dhttp.nonProxyHosts=$(echo "|$noProxy" | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/[[:space:]]//g' | sed -e 's/|\./|\*\./g' | cut -c 2-)"
+  fi
+  echo "$ret"
+}
+
+# ==============================================================================
+
+# Set process name if possible
+exec_args() {
+  EXEC_ARGS=""
+  if [ -n "${JAVA_APP_NAME:-}" ]; then
+    # Not all shells support the 'exec -a newname' syntax..
+    if $(exec -a test true 2>/dev/null); then
+      echo "-a '${JAVA_APP_NAME}'"
+    fi
+  fi
+}
+
+# Combine all java options
+java_options() {
+  # Normalize spaces with awk (i.e. trim and elimate double spaces)
+  # See e.g. https://www.physicsforums.com/threads/awk-1-1-1-file-txt.658865/ for an explanation
+  # of this awk idiom
+  echo "${JAVA_OPTIONS:-} $(run_java_options) $(debug_options) $(proxy_options) $(java_default_options)" | awk '$1=$1'
+}
+
+# Fetch classpath from env or from a local "run-classpath" file
+classpath() {
+  local cp_path="."
+  if [ "${JAVA_LIB_DIR}" != "${JAVA_APP_DIR}" ]; then
+    cp_path="${cp_path}:${JAVA_LIB_DIR}"
+  fi
+  if [ -z "${JAVA_CLASSPATH:-}" ] && [ -n "${JAVA_MAIN_CLASS:-}" ]; then
+    if [ -n "${JAVA_APP_JAR:-}" ]; then
+      cp_path="${cp_path}:${JAVA_APP_JAR}"
+    fi
+    if [ -f "${JAVA_LIB_DIR}/classpath" ]; then
+      # Classpath is pre-created and stored in a 'run-classpath' file
+      cp_path="${cp_path}:$(format_classpath ${JAVA_LIB_DIR}/classpath ${JAVA_APP_JAR:-})"
+    else
+      # No order implied
+      cp_path="${cp_path}:${JAVA_APP_DIR}/*"
+    fi
+  elif [ -n "${JAVA_CLASSPATH:-}" ]; then
+    # Given from the outside
+    cp_path="${JAVA_CLASSPATH}"
+  fi
+  echo "${cp_path}"
+}
+
+# Checks if a flag is present in the arguments.
+hasflag() {
+    local filters="$@"
+    for var in $ARGS; do
+        for filter in $filters; do
+          if [ "$var" = "$filter" ]; then
+              echo 'true'
+              return
+          fi
+        done
+    done
+}
+
+# ==============================================================================
+
+options() {
+    if [ -z ${1:-} ]; then
+      java_options
+      return
+    fi
+
+    local ret=""
+    if [ $(hasflag --debug) ]; then
+      ret="$ret $(debug_options)"
+    fi
+    if [ $(hasflag --proxy) ]; then
+      ret="$ret $(proxy_options)"
+    fi
+    if [ $(hasflag --java-default) ]; then
+      ret="$ret $(java_default_options)"
+    fi
+    if [ $(hasflag --memory) ]; then
+      ret="$ret $(memory_options)"
+    fi
+    if [ $(hasflag --jit) ]; then
+      ret="$ret $(jit_options)"
+    fi
+    if [ $(hasflag --diagnostics) ]; then
+      ret="$ret $(diagnostics_options)"
+    fi
+    if [ $(hasflag --cpu) ]; then
+      ret="$ret $(cpu_options)"
+    fi
+    if [ $(hasflag --gc) ]; then
+      ret="$ret $(gc_options)"
+    fi
+
+    echo $ret | awk '$1=$1'
+}
+
+# Start JVM
+run() {
+  # Initialize environment
+  load_env $(script_dir)
+
+  local args
+  cd ${JAVA_APP_DIR}
+  if [ -n "${JAVA_MAIN_CLASS:-}" ] ; then
+     args="${JAVA_MAIN_CLASS}"
+  elif [ -n "${JAVA_APP_JAR:-}" ]; then
+     args="-jar ${JAVA_APP_JAR}"
+  else
+     echo "Either JAVA_MAIN_CLASS or JAVA_APP_JAR needs to be given"
+     exit 1
+  fi
+  # Don't put ${args} in quotes, otherwise it would be interpreted as a single arg.
+  # However it could be two args (see above). zsh doesn't like this btw, but zsh is not
+  # supported anyway.
+  echo exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
+  exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
+}
+
+# =============================================================================
+# Fire up
+
+# Set env vars reflecting limits
+init_limit_env_vars
+
+first_arg=${1:-}
+if [ "${first_arg}" = "options" ]; then
+  # Print out options only
+  shift
+  options $@
+  exit 0
+elif [ "${first_arg}" = "run" ]; then
+  # Run is the default command, but can be given to allow "options"
+  # as first argument to your
+  shift
+fi
+run "$@"

--- a/images/ubi/openjdk8/jdk/Dockerfile
+++ b/images/ubi/openjdk8/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-398
 
 USER root
 
@@ -6,16 +6,17 @@ RUN mkdir -p /deployments
 
 # JAVA_APP_DIR is used by run-java.sh for finding the binaries
 ENV JAVA_APP_DIR=/deployments \
-    JAVA_MAJOR_VERSION=11
+    JAVA_MAJOR_VERSION=8
 
 
-# /dev/urandom is used as random source, which is perfectly safe
+# /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
-RUN apk add --update \
-    curl \
-    openjdk11=11.0.4_p4-r1 \
- && rm /var/cache/apk/* \
- && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/default-jvm/jre/lib/security/java.security
+RUN microdnf install java-1.8.0-openjdk-headless-1.8.0.242.b08-0.el8_1 \
+      openssl curl ca-certificates \
+    && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
+    && microdnf clean all
+
+ENV JAVA_HOME /etc/alternatives/jre
 
 # Agent bond including Jolokia and jmx_exporter
 ADD agent-bond-opts /opt/run-java-options
@@ -33,5 +34,17 @@ RUN chmod 755 /deployments/run-java.sh
 
 
 
+
+# Run under user "1001" and prepare for be running
+# under OpenShift, too
+RUN chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && chmod g+rw /etc/passwd \
+    && mkdir -p /deployments/data \
+    && chown 1001 /deployments/run-java.sh
+
+# Gives uid
+USER 1001
 
 CMD [ "/deployments/run-java.sh" ]

--- a/images/ubi/openjdk8/jdk/README.md
+++ b/images/ubi/openjdk8/jdk/README.md
@@ -1,0 +1,184 @@
+## Fabric8 Java Base Image OpenJDK 8 (JDK)
+
+
+
+This image is based on UBI and provides OpenJDK 8 (JDK)
+
+It includes:
+
+
+* An [Agent Bond](https://github.com/fabric8io/agent-bond) agent with [Jolokia](http://www.jolokia.org) and Prometheus' [jmx_exporter](https://github.com/prometheus/jmx_exporter). The agent is installed as `/opt/agent-bond/agent-bond.jar`. See below for configuration options.
+
+
+* A startup script [`/deployments/run-java.sh`](#startup-script-run-javash) for starting up Java applications.
+
+### Agent Bond
+
+In order to enable Jolokia for your application you should use this image as a base image (via `FROM`) and use the output of `agent-bond-opts` in your startup scripts to include it in for the Java startup options.
+
+For example, the following snippet can be added to a script starting up your Java application
+
+    # ...
+    export JAVA_OPTIONS="$JAVA_OPTIONS $(agent-bond-opts)"
+    # .... use JAVA_OPTIONS when starting your app, e.g. as Tomcat does
+
+The following versions and defaults are used:
+
+* [Jolokia](http://www.jolokia.org) : version **1.6.2** and port **8778**
+* [jmx_exporter](https://github.com/prometheus/jmx_exporter): version **0.3.1** and port **9779**
+
+You can influence the behaviour of `agent-bond-opts` by setting various environment variables:
+
+### Agent-Bond Options
+
+Agent bond itself can be influenced with the following environment variables: 
+
+* **AB_OFF** : If set disables activation of agent-bond (i.e. echos an empty value). By default, agent-bond is enabled.
+* **AB_ENABLED** : Comma separated list of sub-agents enabled. Currently allowed values are `jolokia` and `jmx_exporter`. 
+  By default both are enabled.
+
+
+#### Jolokia configuration
+
+* **AB_JOLOKIA_CONFIG** : If set uses this file (including path) as Jolokia JVM agent properties (as described 
+  in Jolokia's [reference manual](http://www.jolokia.org/reference/html/agents.html#agents-jvm)).
+  By default this is `/opt/jolokia/jolokia.properties`.
+* **AB_JOLOKIA_HOST** : Host address to bind to (Default: `0.0.0.0`)
+* **AB_JOLOKIA_PORT** : Port to use (Default: `8778`)
+* **AB_JOLOKIA_USER** : User for authentication. By default authentication is switched off.
+* **AB_JOLOKIA_HTTPS** : Switch on secure communication with https. By default self signed server certificates are generated
+  if no `serverCert` configuration is given in `AB_JOLOKIA_OPTS`
+* **AB_JOLOKIA_PASSWORD** : Password for authentication. By default authentication is switched off.
+* **AB_JOLOKIA_ID** : Agent ID to use (`$HOSTNAME` by default, which is the container id)
+* **AB_JOLOKIA_OPTS**  : Additional options to be appended to the agent opts. They should be given in the format 
+  "key=value,key=value,..."
+
+Some options for integration in various environments:
+
+* **AB_JOLOKIA_AUTH_OPENSHIFT** : Switch on client authentication for OpenShift TLS communication. The value of this 
+  parameter can be a relative distinguished name which must be contained in a presented client certificate. Enabling this
+  parameter will automatically switch Jolokia into https communication mode. The default CA cert is set to 
+  `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` 
+  
+#### jmx_exporter configuration
+
+* **AB_JMX_EXPORTER_OPTS** : Configuration to use for `jmx_exporter` (in the format `<port>:<path to config>`)
+* **AB_JMX_EXPORTER_PORT** : Port to use for the JMX Exporter. Default: `9779`
+* **AB_JMX_EXPORTER_CONFIG** : Path to configuration to use for `jmx_exporter`: Default: `/opt/agent-bond/jmx_exporter_config.json`
+
+
+
+### Startup Script run-java.sh
+
+The default command for this image is [/deployments/run-java.sh](https://github.com/fabric8io/run-java-sh). Its purpose it to fire up Java applications which are provided as fat-jars, including all dependencies or more classical from a main class, where the classpath is build up from all jars within a directory.
+
+For these images the variable **JAVA_APP_DIR** has the default value `/deployments`
+
+
+### run-java.sh
+
+This general purpose startup script is optimized for running Java application from within containers. It is called like
+
+```
+./run-java.sh <sub-command> <options>
+```
+`run-java.sh` knows two sub-commands:
+
+* `options` to print out JVM option which can be used for own invocation of Java apps (like Maven or Tomcat). It respects container constraints and includes all magic which is used by this script
+* `run` executes a Java application as described below. This is also the default command so you can skip adding this command.
+
+### Running a Java application
+
+When no subcommand is given (or when you provide the default subcommand `run`), then by default this scripts starts up Java application.
+
+The startup process is configured mostly via environment variables:
+
+* **JAVA_APP_DIR** the directory where the application resides. All paths in your application are relative to this directory. By default it is the same directory where this startup script resides.
+* **JAVA_LIB_DIR** directory holding the Java jar files as well an optional `classpath` file which holds the classpath. Either as a single line classpath (colon separated) or with jar files listed line-by-line. If not set **JAVA_LIB_DIR** is the same as **JAVA_APP_DIR**.
+* **JAVA_OPTIONS** options to add when calling `java`
+* **JAVA_MAJOR_VERSION** a number >= 7. If the version is set then only options suitable for this version are used. When set to 7 options known only to Java > 8 will be removed. For versions >= 10 no explicit memory limit is calculated since Java >= 10 has support for container limits.
+* **JAVA_MAX_MEM_RATIO** is used when no `-Xmx` option is given in `JAVA_OPTIONS`. This is used to calculate a default maximal Heap Memory based on a containers restriction. If used in a Docker container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `25` when the maximum amount of memory available to the container is below 300M, `50` otherwise, which means in that case that 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to 0 in which case no `-Xmx` option is added.
+* **JAVA_INIT_MEM_RATIO** is used when no `-Xms` option is given in `JAVA_OPTIONS`. This is used to calculate a default initial Heap Memory based on a containers restriction. If used in a Docker container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xms` is set to a ratio of the container available memory as set here. By default this value is not set.
+* **JAVA_MAX_CORE** restrict manually the number of cores available which is used for calculating certain defaults like the number of garbage collector threads. If set to 0 no base JVM tuning based on the number of cores is performed.
+* **JAVA_DIAGNOSTICS** set this to get some diagnostics information to standard out when things are happening
+* **JAVA_MAIN_CLASS** A main class to use as argument for `java`. When this environment variable is given, all jar files in `$JAVA_APP_DIR` are added to the classpath as well as `$JAVA_LIB_DIR`.
+* **JAVA_APP_JAR** A jar file with an appropriate manifest so that it can be started with `java -jar` if no `$JAVA_MAIN_CLASS` is set. In all cases this jar file is added to the classpath, too.
+* **JAVA_APP_NAME** Name to use for the process
+* **JAVA_CLASSPATH** the classpath to use. If not given, the startup script checks for a file `${JAVA_APP_DIR}/classpath` and use its content literally as classpath. If this file doesn't exists all jars in the app dir are added (`classes:${JAVA_APP_DIR}/*`).
+* **JAVA_DEBUG** If set remote debugging will be switched on
+* **JAVA_DEBUG_SUSPEND** If set enables suspend mode in remote debugging
+* **JAVA_DEBUG_PORT** Port used for remote debugging. Default: 5005
+* **HTTP_PROXY** The URL of the proxy server that translates into the `http.proxyHost` and `http.proxyPort` system properties.
+* **HTTPS_PROXY** The URL of the proxy server that translates into the `https.proxyHost` and `https.proxyPort` system properties.
+* **no_proxy**, **NO_PROXY** The list of hosts that should be reached directly, bypassing the proxy, that translates into the `http.nonProxyHosts` system property.
+
+If neither `$JAVA_APP_JAR` nor `$JAVA_MAIN_CLASS` is given, `$JAVA_APP_DIR` is checked for a single JAR file which is taken as `$JAVA_APP_JAR`. If no or more then one jar file is found, an error is thrown.
+
+The classpath is build up with the following parts:
+
+* If `$JAVA_CLASSPATH` is set, this classpath is taken.
+* The current directory (".") is added first.
+* If the current directory is not the same as `$JAVA_APP_DIR`, `$JAVA_APP_DIR` is added.
+* If `$JAVA_MAIN_CLASS` is set, then
+  - A `$JAVA_APP_JAR` is added if set
+  - If a file `$JAVA_APP_DIR/classpath` exists, its content is appended to the classpath. This file
+    can be either a single line with the jar files colon separated or a multi-line file where each line
+    holds the path of the jar file relative to `$JAVA_LIB_DIR` (which by default is the `$JAVA_APP_DIR`)
+  - If this file is not set, a `${JAVA_APP_DIR}/*` is added which effectively adds all
+    jars in this directory in alphabetical order.
+
+These variables can be also set in a shell config file `run-env.sh`, which will be sourced by the startup script. This file can be located in the directory where the startup script is located and in `${JAVA_APP_DIR}`, whereas environment variables in the latter override the ones in `run-env.sh` from the script directory.
+
+This startup script also checks for a command `run-java-options`. If existent it will be called and the output is added to the environment variable `$JAVA_OPTIONS`.
+
+The startup script also exposes some environment variables describing container limits which can be used by applications:
+
+* **CONTAINER_CORE_LIMIT** a calculated core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
+* **CONTAINER_MAX_MEMORY** memory limit given to the container
+
+Any arguments given to the script are given through directly as argument to the Java application.
+
+Example:
+
+```
+# Set the application directory directly
+export JAVA_APP_DIR=/deployments
+# Set -Xmx based on container constraints
+export JAVA_MAX_MEM_RATIO=40
+# Start the jar in JAVA_APP_DIR with the given arguments
+./run-java.sh --user maxmorlock --password secret
+```
+
+### Options
+
+This script can also be used to calculate reasonable, best-practice options for starting Java apps in general. For example, when running Maven in a container it makes sense to respect  container Memory constraints.
+
+The subcommand `options` can be used to print options to standard output so that is can be easily used to feed it to another, Java based application.
+
+When no extra arguments are given, all defaults will be used, which can be influenced with the environment variables described above.
+
+You can select specific sets of options by providing additional arguments:
+
+* `--debug` : Java debug options if `JAVA_DEBUG` is set
+* `--memory` : Memory settings based on the environment variables given
+* `--proxy` : Evaluate proxy environments variables
+* `--cpu` : Tuning when the number of cores is limited
+* `--gc` : GC tuning parameters
+* `--jit` : JIT options
+* `--diagnostics` : Print diagnostics options when `JAVA_DIAGNOSTICS` is set
+* `--java-default` : Same as `--memory --jit --diagnostic --cpu --gc`
+
+Example:
+
+```
+# Call Maven with the proper memory settings when running in an container
+export MAVEN_OPTS="$(run-java.sh options --memory)"
+mvn clean install
+```
+
+
+### Versions:
+
+* Base-Image: **UBI 8.1**
+* Java: **OpenJDK 8 1.8.0** (Java Development Kit (JDK))
+* Agent-Bond: **1.2.0** (Jolokia 1.6.2, jmx_exporter 0.3.1)

--- a/images/ubi/openjdk8/jdk/agent-bond-opts
+++ b/images/ubi/openjdk8/jdk/agent-bond-opts
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+# Parse options
+while [ $# -gt 0 ]
+do
+key="$1"
+case ${key} in
+    # Escape for scripts which eval the output of this script
+    -e|--escape)
+    escape_sep=1
+    ;;
+esac
+shift
+done
+
+# Check whether a given config is contained in AB_JOLOKIA_OPTS
+is_in_jolokia_opts() {
+  local prop=$1
+  if [ -n "${AB_JOLOKIA_OPTS:-}" ] && [ "${AB_JOLOKIA_OPTS}" != "${AB_JOLOKIA_OPTS/${prop}/}" ]; then
+     echo "yes"
+  else
+     echo "no"
+  fi
+}
+
+dir=${AB_DIR:-/opt/agent-bond}
+sep="="
+
+# Options separators defined to avoid clash with fish-pepper templating
+ab_open_del="{""{"
+ab_close_del="}""}"
+if [ -n "${escape_sep:-}" ]; then
+  ab_open_del='\{\{'
+  ab_close_del='\}\}'
+fi
+
+if [ -z "${AB_OFF:-}" ]; then
+   opts="-javaagent:$dir/agent-bond.jar"
+   config="${AB_CONFIG:-$dir/agent-bond.properties}"
+   if [ -f "$config" ]; then
+      # Configuration takes precedence
+      opts="${opts}${sep}config=${config}"
+      sep=","
+   fi
+   if [ -z "${AB_ENABLED:-}" ] || [ "${AB_ENABLED}" != "${AB_ENABLED/jolokia/}" ]; then
+     # Direct options only if no configuration is found
+     jsep=""
+     jolokia_opts=""
+     if [ -n "${AB_JOLOKIA_CONFIG:-}" ] && [ -f "${AB_JOLOKIA_CONFIG}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}config=${AB_JOLOKIA_CONFIG}"
+        jsep=","
+        grep -q -e '^host' ${AB_JOLOKIA_CONFIG} && host_in_config=1
+     fi
+     if [ -z "${AB_JOLOKIA_HOST:-}" ] && [ -z "${host_in_config:-}" ]; then
+        AB_JOLOKIA_HOST='0.0.0.0'
+     fi
+     if [ -n "${AB_JOLOKIA_HOST:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}host=${AB_JOLOKIA_HOST}"
+        jsep=","
+     fi
+     if [ -n "${AB_JOLOKIA_PORT:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}port=${AB_JOLOKIA_PORT}"
+        jsep=","
+     fi
+     if [ -n "${AB_JOLOKIA_USER:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}user=${AB_JOLOKIA_USER}"
+        jsep=","
+     fi
+     if [ -n "${AB_JOLOKIA_PASSWORD:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}password=${AB_JOLOKIA_PASSWORD}"
+        jsep=","
+     fi
+     if [ -n "${AB_JOLOKIA_HTTPS:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}protocol=https"
+        https_used=1
+        jsep=","
+     fi
+     # Integration with OpenShift client cert auth
+     if [ -n "${AB_JOLOKIA_AUTH_OPENSHIFT:-}" ]; then
+        auth_opts="useSslClientAuthentication=true,extraClientCheck=true"
+        if [ -z "${https_used+x}" ]; then
+          auth_opts="${auth_opts},protocol=https"
+        fi
+        if [ $(is_in_jolokia_opts "caCert") != "yes" ]; then
+           auth_opts="${auth_opts},caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        fi
+        if [ $(is_in_jolokia_opts "clientPrincipal") != "yes" ]; then
+           if [  "${AB_JOLOKIA_AUTH_OPENSHIFT}" != "${AB_JOLOKIA_AUTH_OPENSHIFT/=/}" ]; then
+              # Supposed to contain a principal name to check
+              auth_opts="${auth_opts},clientPrincipal=$(echo ${AB_JOLOKIA_AUTH_OPENSHIFT} | sed -e 's/ /\\\\ /g')"
+           else
+              auth_opts="${auth_opts},clientPrincipal=cn=system:master-proxy"
+           fi
+        fi
+        jolokia_opts="${jolokia_opts}${jsep}${auth_opts}"
+        jsep=","
+     fi
+     # Add extra opts to the end
+     if [ -n "${AB_JOLOKIA_OPTS:-}" ]; then
+        jolokia_opts="${jolokia_opts}${jsep}${AB_JOLOKIA_OPTS}"
+        jsep=","
+     fi
+
+     opts="${opts}${sep}jolokia${ab_open_del}${jolokia_opts}${ab_close_del}"
+     sep=","
+   fi
+   if [ -z "${AB_ENABLED:-}" ] || [ "${AB_ENABLED}" != "${AB_ENABLED/jmx_exporter/}" ]; then
+     je_opts=""
+     jsep=""
+     if [ -n "${AB_JMX_EXPORTER_OPTS:-}" ]; then
+        opts="${opts}${sep}jmx_exporter${ab_open_del}${AB_JMX_EXPORTER_OPTS}${ab_close_del}"
+        sep=","
+     else
+        port=${AB_JMX_EXPORTER_PORT:-9779}
+        config=${AB_JMX_EXPORTER_CONFIG:-/opt/agent-bond/jmx_exporter_config.yml}
+        opts="${opts}${sep}jmx_exporter${ab_open_del}${port}:${config}${ab_close_del}"
+        sep=","
+     fi
+   fi
+   if [ "${sep:-}" != '=' ] ; then
+     echo ${opts}
+   fi
+fi

--- a/images/ubi/openjdk8/jdk/jmx_exporter_config.yml
+++ b/images/ubi/openjdk8/jdk/jmx_exporter_config.yml
@@ -1,0 +1,28 @@
+---
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+whitelistObjectNames:
+  - 'org.apache.camel:*'
+rules:
+  - pattern: '^org.apache.camel<context=(\w+), type=routes, name=\"(\S+)\"><>((?:Min|Mean|Max|Last|Delta)(?:ProcessingTime)):'
+    name: camel_routes_$3
+    labels:
+      name: $2
+      context: $1
+  - pattern: '^org.apache.camel<context=(\w+), type=routes, name=\"(\S+)\"><>(TotalProcessingTime):'
+    type: COUNTER
+    name: camel_routes_$3
+    labels:
+      name: $2
+      context: $1
+  - pattern: '^org.apache.camel<context=(\w+), type=routes, name=\"(\S+)\"><>(ExchangesInflight|LastProcessingTime):'
+    name: camel_routes_$3
+    labels:
+      name: $2
+      context: $1
+  - pattern: '^org.apache.camel<context=(\w+), type=routes, name=\"(\S+)\"><>((?:Exchanges(?:Completed|Failed|Total))|FailuresHandled):'
+    type: COUNTER
+    name: camel_routes_$3
+    labels:
+      name: $2
+      context: $1

--- a/images/ubi/openjdk8/jdk/run-java.sh
+++ b/images/ubi/openjdk8/jdk/run-java.sh
@@ -1,0 +1,625 @@
+#!/bin/sh
+# ===================================================================================
+# Generic startup script for running arbitrary Java applications with
+# being optimized for running in containers
+#
+# Usage:
+#    # Execute a Java app:
+#    ./run-java.sh <args given to Java code>
+#
+#    # Get options which can be used for invoking Java apps like Maven or Tomcat
+#    ./run-java.sh options [....]
+#
+#
+# This script will pick up either a 'fat' jar which can be run with "-jar"
+# or you can sepcify a JAVA_MAIN_CLASS.
+#
+# Source and Documentation can be found
+# at https://github.com/fabric8io-images/run-java-sh
+#
+# Env-variables evaluated in this script:
+#
+# JAVA_OPTIONS: Checked for already set options
+# JAVA_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
+#                     E.g. the "50" value implies that 50% of the Memory
+#                     given to the container is used as the maximum heap memory with
+#                     '-Xmx'.
+#                     It defaults to "25" when the maximum amount of memory available
+#                     to the container is below 300M, otherwise defaults to "50".
+#                     It is a heuristic and should be better backed up with real
+#                     experiments and measurements.
+#                     For a good overviews what tuning options are available -->
+#                             https://youtu.be/Vt4G-pHXfs4
+#                             https://www.youtube.com/watch?v=w1rZOY5gbvk
+#                             https://vimeo.com/album/4133413/video/181900266
+# Also note that heap is only a small portion of the memory used by a JVM. There are lot
+# of other memory areas (metadata, thread, code cache, ...) which addes to the overall
+# size. When your container gets killed because of an OOM, then you should tune
+# the absolute values.
+# JAVA_INIT_MEM_RATIO: Ratio use to calculate a default intial heap memory, in percent.
+#                      By default this value is not set.
+#
+# The following variables are exposed to your Java application:
+#
+# CONTAINER_MAX_MEMORY: Max memory for the container (if running within a container)
+# MAX_CORE_LIMIT: Number of cores available for the container (if running within a container)
+
+
+# ==========================================================
+
+# Fail on a single failed command in a pipeline (if supported)
+(set -o | grep -q pipefail) && set -o pipefail
+
+# Fail on error and undefined vars
+set -eu
+
+# Save global script args
+ARGS="$@"
+
+# ksh is different for defining local vars
+if [ -n "${KSH_VERSION:-}" ]; then
+  alias local=typeset
+fi
+
+# Error is indicated with a prefix in the return value
+check_error() {
+  local error_msg="$1"
+  if echo "${error_msg}" | grep -q "^ERROR:"; then
+    echo "${error_msg}"
+    exit 1
+  fi
+}
+
+# The full qualified directory where this script is located in
+script_dir() {
+  # Default is current directory
+  local dir=$(dirname "$0")
+  local full_dir=$(cd "${dir}" && pwd)
+  echo ${full_dir}
+}
+
+# Try hard to find a sane default jar-file
+auto_detect_jar_file() {
+  local dir="$1"
+
+  # Filter out temporary jars from the shade plugin which start with 'original-'
+  local old_dir="$(pwd)"
+  cd ${dir}
+  if [ $? = 0 ]; then
+    # NB: Find both (single) JAR *or* WAR <https://github.com/fabric8io-images/run-java-sh/issues/79>
+    local nr_jars="$(ls 2>/dev/null | grep -e '.*\.jar$' -e '.*\.war$' | grep -v '^original-' | wc -l | awk '{print $1}')"
+    if [ "${nr_jars}" = 1 ]; then
+      ls 2>/dev/null | grep -e '.*\.jar$' -e '.*\.war$' | grep -v '^original-'
+      exit 0
+    fi
+    cd "${old_dir}"
+    echo "ERROR: Neither JAVA_MAIN_CLASS nor JAVA_APP_JAR is set and ${nr_jars} found in ${dir} (1 expected)"
+  else
+    echo "ERROR: No directory ${dir} found for auto detection"
+  fi
+}
+
+# Check directories (arg 2...n) for a jar file (arg 1)
+find_jar_file() {
+  local jar="$1"
+  shift;
+
+  # Absolute path check if jar specifies an absolute path
+  if [ "${jar}" != ${jar#/} ]; then
+    if [ -f "${jar}" ]; then
+      echo "${jar}"
+    else
+      echo "ERROR: No such file ${jar}"
+    fi
+  else
+    for dir in $*; do
+      if [ -f "${dir}/$jar" ]; then
+        echo "${dir}/$jar"
+        return
+      fi
+    done
+    echo "ERROR: No ${jar} found in $*"
+  fi
+}
+
+# Generic formula evaluation based on awk
+calc() {
+  local formula="$1"
+  shift
+  echo "$@" | awk '
+    function ceil(x) {
+      return x % 1 ? int(x) + 1 : x
+    }
+    function log2(x) {
+      return log(x)/log(2)
+    }
+    function max2(x, y) {
+      return x > y ? x : y
+    }
+    function round(x) {
+      return int(x + 0.5)
+    }
+    {print '"int(${formula})"'}
+  '
+}
+
+# Based on the cgroup limits, figure out the max number of core we should utilize
+core_limit() {
+  local cpu_period_file="/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+  local cpu_quota_file="/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+  if [ -r "${cpu_period_file}" ]; then
+    local cpu_period="$(cat ${cpu_period_file})"
+
+    if [ -r "${cpu_quota_file}" ]; then
+      local cpu_quota="$(cat ${cpu_quota_file})"
+      # cfs_quota_us == -1 --> no restrictions
+      if [ ${cpu_quota:-0} -ne -1 ]; then
+        echo $(calc 'ceil($1/$2)' "${cpu_quota}" "${cpu_period}")
+      fi
+    fi
+  fi
+}
+
+max_memory() {
+  # High number which is the max limit until which memory is supposed to be
+  # unbounded.
+  local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+  if [ -r "${mem_file}" ]; then
+    local max_mem_cgroup="$(cat ${mem_file})"
+    local max_mem_meminfo_kb="$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')"
+    local max_mem_meminfo="$(expr $max_mem_meminfo_kb \* 1024)"
+    if [ ${max_mem_cgroup:-0} != -1 ] && [ ${max_mem_cgroup:-0} -lt ${max_mem_meminfo:-0} ]
+    then
+      echo "${max_mem_cgroup}"
+    fi
+  fi
+}
+
+init_limit_env_vars() {
+  # Read in container limits and export the as environment variables
+  local core_limit="$(core_limit)"
+  if [ -n "${core_limit}" ]; then
+    export CONTAINER_CORE_LIMIT="${core_limit}"
+  fi
+
+  local mem_limit="$(max_memory)"
+  if [ -n "${mem_limit}" ]; then
+    export CONTAINER_MAX_MEMORY="${mem_limit}"
+  fi
+}
+
+load_env() {
+  local script_dir="$1"
+
+  # Configuration stuff is read from this file
+  local run_env_sh="run-env.sh"
+
+  # Load default default config
+  if [ -f "${script_dir}/${run_env_sh}" ]; then
+    . "${script_dir}/${run_env_sh}"
+  fi
+
+  # Check also $JAVA_APP_DIR. Overrides other defaults
+  # It's valid to set the app dir in the default script
+  JAVA_APP_DIR="${JAVA_APP_DIR:-${script_dir}}"
+  if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
+    . "${JAVA_APP_DIR}/${run_env_sh}"
+  fi
+  export JAVA_APP_DIR
+
+  # JAVA_LIB_DIR defaults to JAVA_APP_DIR
+  export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"
+  if [ -z "${JAVA_MAIN_CLASS:-}" ] && [ -z "${JAVA_APP_JAR:-}" ]; then
+    JAVA_APP_JAR="$(auto_detect_jar_file ${JAVA_APP_DIR})"
+    check_error "${JAVA_APP_JAR}"
+  fi
+
+  if [ -n "${JAVA_APP_JAR:-}" ]; then
+    local jar="$(find_jar_file ${JAVA_APP_JAR} ${JAVA_APP_DIR} ${JAVA_LIB_DIR})"
+    check_error "${jar}"
+    export JAVA_APP_JAR="${jar}"
+  else
+    export JAVA_MAIN_CLASS
+  fi
+}
+
+# Check for standard /opt/run-java-options first, fallback to run-java-options in the path if not existing
+run_java_options() {
+  if [ -f "/opt/run-java-options" ]; then
+    echo "$(. /opt/run-java-options)"
+  else
+    which run-java-options >/dev/null 2>&1
+    if [ $? = 0 ]; then
+      echo "$(run-java-options)"
+    fi
+  fi
+}
+
+debug_options() {
+  if [ -n "${JAVA_ENABLE_DEBUG:-}" ] || [ -n "${JAVA_DEBUG_ENABLE:-}" ] ||  [ -n "${JAVA_DEBUG:-}" ]; then
+    local debug_port="${JAVA_DEBUG_PORT:-5005}"
+    local suspend_mode="n"
+    if [ -n "${JAVA_DEBUG_SUSPEND:-}" ]; then
+      if ! echo "${JAVA_DEBUG_SUSPEND}" | grep -q -e '^\(false\|n\|no\|0\)$'; then
+        suspend_mode="y"
+      fi
+    fi
+    echo "-agentlib:jdwp=transport=dt_socket,server=y,suspend=${suspend_mode},address=${debug_port}"
+  fi
+}
+
+# Read in a classpath either from a file with a single line, colon separated
+# or given line-by-line in separate lines
+# Arg 1: path to claspath (must exist), optional arg2: application jar, which is stripped from the classpath in
+# multi line arrangements
+format_classpath() {
+  local cp_file="$1"
+  local app_jar="${2:-}"
+
+  local wc_out="$(wc -l $1 2>&1)"
+  if [ $? -ne 0 ]; then
+    echo "Cannot read lines in ${cp_file}: $wc_out"
+    exit 1
+  fi
+
+  local nr_lines=$(echo $wc_out | awk '{ print $1 }')
+  if [ ${nr_lines} -gt 1 ]; then
+    local sep=""
+    local classpath=""
+    while read file; do
+      local full_path="${JAVA_LIB_DIR}/${file}"
+      # Don't include app jar if include in list
+      if [ "${app_jar}" != "${full_path}" ]; then
+        classpath="${classpath}${sep}${full_path}"
+      fi
+      sep=":"
+    done < "${cp_file}"
+    echo "${classpath}"
+  else
+    # Supposed to be a single line, colon separated classpath file
+    cat "${cp_file}"
+  fi
+}
+
+# ==========================================================================
+
+memory_options() {
+  echo "$(calc_init_memory) $(calc_max_memory)"
+  return
+}
+
+# Check for memory options and set max heap size if needed
+calc_max_memory() {
+  # Check whether -Xmx is already given in JAVA_OPTIONS
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xmx"; then
+    return
+  fi
+
+  if [ -z "${CONTAINER_MAX_MEMORY:-}" ]; then
+    return
+  fi
+
+  # Check for the 'real memory size' and calculate Xmx from the ratio
+  if [ -n "${JAVA_MAX_MEM_RATIO:-}" ]; then
+    if [ "${JAVA_MAX_MEM_RATIO}" -eq 0 ]; then
+      # Explicitely switched off
+      return
+    fi
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"
+  # When JAVA_MAX_MEM_RATIO not set and JVM >= 10 no max_memory
+  elif [ "${JAVA_MAJOR_VERSION:-0}" -ge "10" ]; then
+    return
+  elif [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
+    # Restore the one-fourth default heap size instead of the one-half below 300MB threshold
+    # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html#default_heap_size
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "25" "mx"
+  else
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "50" "mx"
+  fi
+}
+
+# Check for memory options and set initial heap size if requested
+calc_init_memory() {
+  # Check whether -Xms is already given in JAVA_OPTIONS.
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xms"; then
+    return
+  fi
+
+  # Check if value set
+  if [ -z "${JAVA_INIT_MEM_RATIO:-}" ] || [ -z "${CONTAINER_MAX_MEMORY:-}" ] || [ "${JAVA_INIT_MEM_RATIO}" -eq 0 ]; then
+    return
+  fi
+
+  # Calculate Xms from the ratio given
+  calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_INIT_MEM_RATIO}" "ms"
+}
+
+calc_mem_opt() {
+  local max_mem="$1"
+  local fraction="$2"
+  local mem_opt="$3"
+
+  local val=$(calc 'round($1*$2/100/1048576)' "${max_mem}" "${fraction}")
+  echo "-X${mem_opt}${val}m"
+}
+
+c2_disabled() {
+  if [ -n "${CONTAINER_MAX_MEMORY:-}" ]; then
+    # Disable C2 compiler when container memory <=300MB
+    if [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
+      echo true
+      return
+    fi
+  fi
+  echo false
+}
+
+jit_options() {
+  if [ "${JAVA_MAJOR_VERSION:-0}" -ge "10" ]; then
+    return
+  fi
+  # Check whether -XX:TieredStopAtLevel is already given in JAVA_OPTIONS
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-XX:TieredStopAtLevel"; then
+    return
+  fi
+  if [ $(c2_disabled) = true ]; then
+    echo "-XX:TieredStopAtLevel=1"
+  fi
+}
+
+# Switch on diagnostics except when switched off
+diagnostics_options() {
+  if [ -n "${JAVA_DIAGNOSTICS:-}" ]; then
+    if [ "${JAVA_MAJOR_VERSION:-0}" -ge "11" ]; then
+      echo "-XX:NativeMemoryTracking=summary -Xlog:gc*:stdout:time -XX:+UnlockDiagnosticVMOptions"
+    else
+      echo "-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
+    fi
+  fi
+}
+
+# Replicate thread ergonomics for tiered compilation.
+# This could ideally be skipped when tiered compilation is disabled.
+# The algorithm is taken from:
+# OpenJDK / jdk8u / jdk8u / hotspot
+# src/share/vm/runtime/advancedThresholdPolicy.cpp
+ci_compiler_count() {
+  local core_limit="$1"
+  local log_cpu=$(calc 'log2($1)' "$core_limit")
+  local loglog_cpu=$(calc 'log2(max2($1,1))' "$log_cpu")
+  local count=$(calc 'max2($1*$2,1)*3/2' "$log_cpu" "$loglog_cpu")
+  local c1_count=$(calc 'max2($1/3,1)' "$count")
+  local c2_count=$(calc 'max2($1-$2,1)' "$count" "$c1_count")
+  [ $(c2_disabled) = true ] && echo "$c1_count" || echo $(calc '$1+$2' "$c1_count" "$c2_count")
+}
+
+cpu_options() {
+  # JVMs >= 10 know about CPU limits
+  if [ "${JAVA_MAJOR_VERSION:-0}" -ge "10" ]; then
+    return
+  fi
+
+  local core_limit="${JAVA_CORE_LIMIT:-}"
+  if [ "$core_limit" = "0" ]; then
+    return
+  fi
+
+  if [ -n "${CONTAINER_CORE_LIMIT:-}" ]; then
+    if [ -z ${core_limit} ]; then
+      core_limit="${CONTAINER_CORE_LIMIT}"
+    fi
+    echo "-XX:ParallelGCThreads=${core_limit} " \
+         "-XX:ConcGCThreads=${core_limit} " \
+         "-Djava.util.concurrent.ForkJoinPool.common.parallelism=${core_limit} " \
+         "-XX:CICompilerCount=$(ci_compiler_count $core_limit)"
+  fi
+}
+
+#-XX:MinHeapFreeRatio=20  These parameters tell the heap to shrink aggressively and to grow conservatively.
+#-XX:MaxHeapFreeRatio=40  Thereby optimizing the amount of memory available to the operating system.
+heap_ratio() {
+  echo "-XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40"
+}
+
+# These parameters are necessary when running parallel GC if you want to use the Min and Max Heap Free ratios.
+# Skip setting gc_options if any other GC is set in JAVA_OPTIONS.
+# -XX:GCTimeRatio=4
+# -XX:AdaptiveSizePolicyWeight=90
+gc_options() {
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-XX:.*Use.*GC"; then
+    return
+  fi
+
+  local opts=""
+  # for JVMs < 10 set GC settings
+  if [ -z "${JAVA_MAJOR_VERSION:-}" ] || [ "${JAVA_MAJOR_VERSION:-0}" -lt "10" ]; then
+    opts="${opts} -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 $(heap_ratio)"
+  fi
+  if [ -z "${JAVA_MAJOR_VERSION:-}" ] || [ "${JAVA_MAJOR_VERSION:-}" != "7" ]; then
+    opts="${opts} -XX:+ExitOnOutOfMemoryError"
+  fi
+  echo $opts
+}
+
+java_default_options() {
+  # Echo options, trimming trailing and multiple spaces
+  echo "$(memory_options) $(jit_options) $(diagnostics_options) $(cpu_options) $(gc_options)" | awk '$1=$1'
+
+}
+
+# ==============================================================================
+
+# parse the URL
+parse_url() {
+  #[scheme://][user[:password]@]host[:port][/path][?params]
+  echo "$1" | sed -e "s+^\(\([^:]*\)://\)\?\(\([^:@]*\)\(:\([^@]*\)\)\?@\)\?\([^:/?]*\)\(:\([^/?]*\)\)\?.*$+ local scheme='\2' username='\4' password='\6' hostname='\7' port='\9'+"
+}
+
+java_proxy_options() {
+  local url="$1"
+  local transport="$2"
+  local ret=""
+
+  if [ -n "$url" ] ; then
+    eval $(parse_url "$url")
+    if [ -n "$hostname" ] ; then
+      ret="-D${transport}.proxyHost=${hostname}"
+    fi
+    if [ -n "$port" ] ; then
+      ret="$ret -D${transport}.proxyPort=${port}"
+    fi
+    if [ -n "$username" -o -n "$password" ] ; then
+      echo "WARNING: Proxy URL for ${transport} contains authentication credentials, these are not supported by java" >&2
+    fi
+  fi
+  echo "$ret"
+}
+
+# Check for proxy options and echo if enabled.
+proxy_options() {
+  local ret=""
+  ret="$(java_proxy_options "${https_proxy:-${HTTPS_PROXY:-}}" https)"
+  ret="$ret $(java_proxy_options "${http_proxy:-${HTTP_PROXY:-}}" http)"
+
+  local noProxy="${no_proxy:-${NO_PROXY:-}}"
+  if [ -n "$noProxy" ] ; then
+    ret="$ret -Dhttp.nonProxyHosts=$(echo "|$noProxy" | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/[[:space:]]//g' | sed -e 's/|\./|\*\./g' | cut -c 2-)"
+  fi
+  echo "$ret"
+}
+
+# ==============================================================================
+
+# Set process name if possible
+exec_args() {
+  EXEC_ARGS=""
+  if [ -n "${JAVA_APP_NAME:-}" ]; then
+    # Not all shells support the 'exec -a newname' syntax..
+    if $(exec -a test true 2>/dev/null); then
+      echo "-a '${JAVA_APP_NAME}'"
+    fi
+  fi
+}
+
+# Combine all java options
+java_options() {
+  # Normalize spaces with awk (i.e. trim and elimate double spaces)
+  # See e.g. https://www.physicsforums.com/threads/awk-1-1-1-file-txt.658865/ for an explanation
+  # of this awk idiom
+  echo "${JAVA_OPTIONS:-} $(run_java_options) $(debug_options) $(proxy_options) $(java_default_options)" | awk '$1=$1'
+}
+
+# Fetch classpath from env or from a local "run-classpath" file
+classpath() {
+  local cp_path="."
+  if [ "${JAVA_LIB_DIR}" != "${JAVA_APP_DIR}" ]; then
+    cp_path="${cp_path}:${JAVA_LIB_DIR}"
+  fi
+  if [ -z "${JAVA_CLASSPATH:-}" ] && [ -n "${JAVA_MAIN_CLASS:-}" ]; then
+    if [ -n "${JAVA_APP_JAR:-}" ]; then
+      cp_path="${cp_path}:${JAVA_APP_JAR}"
+    fi
+    if [ -f "${JAVA_LIB_DIR}/classpath" ]; then
+      # Classpath is pre-created and stored in a 'run-classpath' file
+      cp_path="${cp_path}:$(format_classpath ${JAVA_LIB_DIR}/classpath ${JAVA_APP_JAR:-})"
+    else
+      # No order implied
+      cp_path="${cp_path}:${JAVA_APP_DIR}/*"
+    fi
+  elif [ -n "${JAVA_CLASSPATH:-}" ]; then
+    # Given from the outside
+    cp_path="${JAVA_CLASSPATH}"
+  fi
+  echo "${cp_path}"
+}
+
+# Checks if a flag is present in the arguments.
+hasflag() {
+    local filters="$@"
+    for var in $ARGS; do
+        for filter in $filters; do
+          if [ "$var" = "$filter" ]; then
+              echo 'true'
+              return
+          fi
+        done
+    done
+}
+
+# ==============================================================================
+
+options() {
+    if [ -z ${1:-} ]; then
+      java_options
+      return
+    fi
+
+    local ret=""
+    if [ $(hasflag --debug) ]; then
+      ret="$ret $(debug_options)"
+    fi
+    if [ $(hasflag --proxy) ]; then
+      ret="$ret $(proxy_options)"
+    fi
+    if [ $(hasflag --java-default) ]; then
+      ret="$ret $(java_default_options)"
+    fi
+    if [ $(hasflag --memory) ]; then
+      ret="$ret $(memory_options)"
+    fi
+    if [ $(hasflag --jit) ]; then
+      ret="$ret $(jit_options)"
+    fi
+    if [ $(hasflag --diagnostics) ]; then
+      ret="$ret $(diagnostics_options)"
+    fi
+    if [ $(hasflag --cpu) ]; then
+      ret="$ret $(cpu_options)"
+    fi
+    if [ $(hasflag --gc) ]; then
+      ret="$ret $(gc_options)"
+    fi
+
+    echo $ret | awk '$1=$1'
+}
+
+# Start JVM
+run() {
+  # Initialize environment
+  load_env $(script_dir)
+
+  local args
+  cd ${JAVA_APP_DIR}
+  if [ -n "${JAVA_MAIN_CLASS:-}" ] ; then
+     args="${JAVA_MAIN_CLASS}"
+  elif [ -n "${JAVA_APP_JAR:-}" ]; then
+     args="-jar ${JAVA_APP_JAR}"
+  else
+     echo "Either JAVA_MAIN_CLASS or JAVA_APP_JAR needs to be given"
+     exit 1
+  fi
+  # Don't put ${args} in quotes, otherwise it would be interpreted as a single arg.
+  # However it could be two args (see above). zsh doesn't like this btw, but zsh is not
+  # supported anyway.
+  echo exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
+  exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
+}
+
+# =============================================================================
+# Fire up
+
+# Set env vars reflecting limits
+init_limit_env_vars
+
+first_arg=${1:-}
+if [ "${first_arg}" = "options" ]; then
+  # Print out options only
+  shift
+  options $@
+  exit 0
+elif [ "${first_arg}" = "run" ]; then
+  # Run is the default command, but can be given to allow "options"
+  # as first argument to your
+  shift
+fi
+run "$@"

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -9,7 +9,8 @@ ENV JAVA_APP_DIR={{= fp.config.base.baseDir }} \
     JAVA_MAJOR_VERSION={{= fp.config.version.major }}
 
 {{= fp.block("java-pkg-" + fp.param.base) || ''}}
-{{= fp.block(fp.config.base.agent, "install", { dest: "/opt/run-java-options" }) }}
+{{= fp.block(fp.config.base.agent + "-install", { dest: "/opt/run-java-options" }) }}
+
 {{= fp.block("run-java-sh","copy",{dest: fp.config.base.baseDir}) }}
 
 {{? fp.config.base.user }}
@@ -25,5 +26,17 @@ RUN {{? fp.config.base.createUser }}groupadd -r {{= fp.config.base.user }} -g 10
 
 USER {{= fp.config.base.user }}
 {{?}}
+{{? fp.config.base.ubiUser }}
+# Run under user "{{= fp.config.base.ubiUser }}" and prepare for be running
+# under OpenShift, too
+RUN chown {{= fp.config.base.ubiUser }} {{= fp.config.base.baseDir }} \
+    && chmod "g+rwX" {{= fp.config.base.baseDir }} \
+    && chown {{= fp.config.base.ubiUser }}:root {{= fp.config.base.baseDir }} \
+    && chmod g+rw /etc/passwd \
+    && mkdir -p {{= fp.config.base.baseDir }}/data \
+    && chown {{= fp.config.base.ubiUser }} {{= fp.config.base.baseDir }}/run-java.sh
 
+# Gives uid
+USER {{= fp.config.base.ubiUser }}
+{{?}}
 CMD [ "{{= fp.config.base.baseDir }}/run-java.sh" ]


### PR DESCRIPTION
In relation with fabric8io-images/java#56

New UBI based images require different methods for declaring user and settings permissions so I create a new template block specific to UBI.

Also faced an issue for retrieving agent-bond that is no longer available on old Maven central repo URL. As `agent-bond` repository is now in archive mode, I created a local `install` block that allows redefinition of URL.