### PR TITLE
Upgrade OpenJDK on CentOS

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -33,7 +33,7 @@ config:
       javaPackage:
         7: 1.7.0.231-2.6.19.2.el7_7
         8: 1.8.0.242.b08-0.el7_7
-        11: 11.0.5.10-0.el7_7
+        11: 11.0.6.10-1.el7_7
     jboss:
       deprecated: true
       from: "jboss/base-jdk"

--- a/images.yml
+++ b/images.yml
@@ -31,7 +31,7 @@ config:
       version: "7"
       description: "CentOS"
       javaPackage:
-        7: 1.7.0.231-2.6.19.2.el7_7
+        7: 1.7.0.251-2.6.21.0.el7_7
         8: 1.8.0.242.b08-0.el7_7
         11: 11.0.6.10-1.el7_7
     jboss:

--- a/images.yml
+++ b/images.yml
@@ -32,7 +32,7 @@ config:
       description: "CentOS"
       javaPackage:
         7: 1.7.0.231-2.6.19.2.el7_7
-        8: 1.8.0.232.b09-0.el7_7
+        8: 1.8.0.242.b08-0.el7_7
         11: 11.0.5.10-0.el7_7
     jboss:
       deprecated: true

--- a/images/centos/openjdk11/jdk/Dockerfile
+++ b/images/centos/openjdk11/jdk/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-11-openjdk-11.0.5.10-0.el7_7 \ 
-       java-11-openjdk-devel-11.0.5.10-0.el7_7 \ 
+       java-11-openjdk-11.0.6.10-1.el7_7 \ 
+       java-11-openjdk-devel-11.0.6.10-1.el7_7 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk11/jre/Dockerfile
+++ b/images/centos/openjdk11/jre/Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-11-openjdk-11.0.5.10-0.el7_7 \ 
+       java-11-openjdk-11.0.6.10-1.el7_7 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk7/jdk/Dockerfile
+++ b/images/centos/openjdk7/jdk/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-1.7.0-openjdk-1.7.0.231-2.6.19.2.el7_7 \ 
-       java-1.7.0-openjdk-devel-1.7.0.231-2.6.19.2.el7_7 \ 
+       java-1.7.0-openjdk-1.7.0.251-2.6.21.0.el7_7 \ 
+       java-1.7.0-openjdk-devel-1.7.0.251-2.6.21.0.el7_7 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk7/jre/Dockerfile
+++ b/images/centos/openjdk7/jre/Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-1.7.0-openjdk-1.7.0.231-2.6.19.2.el7_7 \ 
+       java-1.7.0-openjdk-1.7.0.251-2.6.21.0.el7_7 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk8/jdk/Dockerfile
+++ b/images/centos/openjdk8/jdk/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-1.8.0-openjdk-1.8.0.232.b09-0.el7_7 \ 
-       java-1.8.0-openjdk-devel-1.8.0.232.b09-0.el7_7 \ 
+       java-1.8.0-openjdk-1.8.0.242.b08-0.el7_7 \ 
+       java-1.8.0-openjdk-devel-1.8.0.242.b08-0.el7_7 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk8/jre/Dockerfile
+++ b/images/centos/openjdk8/jre/Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-1.8.0-openjdk-1.8.0.232.b09-0.el7_7 \ 
+       java-1.8.0-openjdk-1.8.0.242.b08-0.el7_7 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 


### PR DESCRIPTION
- Upgrade to OpenJDK 7u251 on CentOS 
  https://centos.pkgs.org/7/centos-updates-x86_64/java-1.7.0-openjdk-1.7.0.251-2.6.21.0.el7_7.x86_64.rpm.html
- Upgrade to OpenJDK 8u242 on CentOS 
  https://centos.pkgs.org/7/centos-updates-x86_64/java-1.8.0-openjdk-1.8.0.242.b08- 
  0.el7_7.x86_64.rpm.html

  Closes: #58
- Upgrade to OpenJDK 11.0.6 on CentOS
   https://centos.pkgs.org/7/centos-updates-x86_64/java-11-openjdk-11.0.6.10-1.el7_7.x86_64.rpm.html