### PR TITLE
Update centos versions

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -25,15 +25,15 @@ config:
         8: 8.242.08-r0
         11: 11.0.5_p10-r0
     centos:
-      from: "centos:7.7.1908"
+      from: "centos:7.8.2003"
       createUser: true
       user: "jboss"
       version: "7"
       description: "CentOS"
       javaPackage:
-        7: 1.7.0.251-2.6.21.1.el7
-        8: 1.8.0.242.b08-1.el7
-        11: 11.0.6.10-3.el7
+        7: 1.7.0.261-2.6.22.2.el7_8
+        8: 1.8.0.262.b10-0.el7_8
+        11: 11.0.8.10-0.el7_8
     ubi:
       from: "registry.access.redhat.com/ubi8/ubi-minimal:8.2-267"
       createUser: false

--- a/images/centos/openjdk11/jdk/Dockerfile
+++ b/images/centos/openjdk11/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.7.1908
+FROM centos:7.8.2003
 
 USER root
 
@@ -12,8 +12,8 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-11-openjdk-11.0.6.10-3.el7 \ 
-       java-11-openjdk-devel-11.0.6.10-3.el7 \ 
+       java-11-openjdk-11.0.8.10-0.el7_8 \ 
+       java-11-openjdk-devel-11.0.8.10-0.el7_8 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk11/jre/Dockerfile
+++ b/images/centos/openjdk11/jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.7.1908
+FROM centos:7.8.2003
 
 USER root
 
@@ -12,7 +12,7 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-11-openjdk-11.0.6.10-3.el7 \ 
+       java-11-openjdk-11.0.8.10-0.el7_8 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk7/jdk/Dockerfile
+++ b/images/centos/openjdk7/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.7.1908
+FROM centos:7.8.2003
 
 USER root
 
@@ -12,8 +12,8 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-1.7.0-openjdk-1.7.0.251-2.6.21.1.el7 \ 
-       java-1.7.0-openjdk-devel-1.7.0.251-2.6.21.1.el7 \ 
+       java-1.7.0-openjdk-1.7.0.261-2.6.22.2.el7_8 \ 
+       java-1.7.0-openjdk-devel-1.7.0.261-2.6.22.2.el7_8 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk7/jre/Dockerfile
+++ b/images/centos/openjdk7/jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.7.1908
+FROM centos:7.8.2003
 
 USER root
 
@@ -12,7 +12,7 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-1.7.0-openjdk-1.7.0.251-2.6.21.1.el7 \ 
+       java-1.7.0-openjdk-1.7.0.261-2.6.22.2.el7_8 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk8/jdk/Dockerfile
+++ b/images/centos/openjdk8/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.7.1908
+FROM centos:7.8.2003
 
 USER root
 
@@ -12,8 +12,8 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-1.8.0-openjdk-1.8.0.242.b08-1.el7 \ 
-       java-1.8.0-openjdk-devel-1.8.0.242.b08-1.el7 \ 
+       java-1.8.0-openjdk-1.8.0.262.b10-0.el7_8 \ 
+       java-1.8.0-openjdk-devel-1.8.0.262.b10-0.el7_8 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 

--- a/images/centos/openjdk8/jre/Dockerfile
+++ b/images/centos/openjdk8/jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.7.1908
+FROM centos:7.8.2003
 
 USER root
 
@@ -12,7 +12,7 @@ ENV JAVA_APP_DIR=/deployments \
 # /dev/urandom is used as random source, which is prefectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN yum install -y \
-       java-1.8.0-openjdk-1.8.0.242.b08-1.el7 \ 
+       java-1.8.0-openjdk-1.8.0.262.b10-0.el7_8 \ 
     && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/jre/lib/security/java.security \
     && yum clean all
 


### PR DESCRIPTION
Update to the latest of centos 7 and to the latest available jdks.
I have not updated centos to 8 as there is not java 7 package available. In my opinion java 7 could be dropped.